### PR TITLE
schemeshard: per-op module pattern (CreateTable pilot) + ss_tool inspector

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -5,13 +5,19 @@
 
 namespace NKikimr::NSchemeShard {
 
-enum EOperationClass {
-    Create = 0,
-    Alter,
-    Drop,
-    Other,
-    Unknown
-};
+// EOperationClass is declared in schemeshard__op_traits.h so that per-op
+// TSchemeTxTraits<> specializations can carry their classification as a
+// compile-time constant. Each migrated op asserts parity with the switch
+// below via static_assert; eventually the switch is replaced by a generated
+// dispatch over TSchemeTxTraits<op>::Class.
+
+// Parity check: classification carried by TSchemeTxTraits<> must match the
+// switch below. Add one of these for every op as it migrates to the per-op
+// module pattern; once all ops are covered the switch goes away entirely.
+static_assert(
+    TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::Class
+    == EOperationClass::Create,
+    "ESchemeOpCreateTable trait Class diverges from GetOperationClass()");
 
 EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
     switch (op) {

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -5,19 +5,10 @@
 
 namespace NKikimr::NSchemeShard {
 
-// EOperationClass is declared in schemeshard__op_traits.h so that per-op
-// TSchemeTxTraits<> specializations can carry their classification as a
-// compile-time constant. Each migrated op asserts parity with the switch
-// below via static_assert; eventually the switch is replaced by a generated
-// dispatch over TSchemeTxTraits<op>::Class.
-
-// Parity check: classification carried by TSchemeTxTraits<> must match the
-// switch below. Add one of these for every op as it migrates to the per-op
-// module pattern; once all ops are covered the switch goes away entirely.
+// Parity guard: trait Class must match this switch for every migrated op.
 static_assert(
     TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::Class
-    == EOperationClass::Create,
-    "ESchemeOpCreateTable trait Class diverges from GetOperationClass()");
+    == EOperationClass::Create);
 
 EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
     switch (op) {

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -15,10 +15,19 @@ namespace NKikimr::NSchemeShard {
 
 using TTxTransaction = NKikimrSchemeOp::TModifyScheme;
 
+enum EOperationClass {
+    Create = 0,
+    Alter,
+    Drop,
+    Other,
+    Unknown
+};
+
 struct TSchemeTxTraitsFallback {
     constexpr inline static bool CreateDirsFromName = false;
     constexpr inline static bool CreateAdditionalDirs = false;
     constexpr inline static bool NeedRewrite = false;
+    constexpr inline static EOperationClass Class = EOperationClass::Unknown;
 };
 
 template <NKikimrSchemeOp::EOperationType opType>
@@ -36,6 +45,16 @@ struct TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>
     : public TSchemeTxTraitsFallback
 {
     constexpr inline static bool CreateDirsFromName = true;
+    constexpr inline static EOperationClass Class = EOperationClass::Create;
+
+    static TVector<ISubOperation::TPtr> MakeOperationParts(
+        const TOperation& op,
+        const TTxTransaction& tx,
+        TOperationContext& context);
+
+    static void CollectChangingPaths(
+        const TTxTransaction& tx,
+        TVector<TString>& out);
 };
 
 template <>

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -10,6 +10,7 @@
 #include <util/generic/string.h>
 
 #include <optional>
+#include <utility>  // std::declval, used by Describe<>()
 
 namespace NKikimr::NSchemeShard {
 
@@ -280,5 +281,45 @@ bool Rewrite(TTraits traits, TTxTransaction& tx) {
 }
 
 bool IsCreatePathOperation(NKikimrSchemeOp::EOperationType op);
+
+// --- Trait description -----------------------------------------------------
+//
+// Materialized snapshot of the static-constexpr fields of a TSchemeTxTraits<>
+// specialization. Lives next to the trait itself so the trait header is the
+// single source of truth for "what an op-trait carries"; tooling (ss_tool,
+// docs codegen, etc.) consumes this struct instead of mirroring the field
+// list. When you add a field to TSchemeTxTraitsFallback, also add it here
+// and extend Describe() below; nothing else needs to change.
+
+struct TOpDescriptor {
+    EOperationClass Class = EOperationClass::Unknown;
+    bool CreateDirsFromName = false;
+    bool CreateAdditionalDirs = false;
+    bool NeedRewrite = false;
+    // Derived: which of the per-op module static methods the trait declares.
+    bool HasMakeOperationParts = false;
+    bool HasCollectChangingPaths = false;
+};
+
+template <class Traits>
+constexpr TOpDescriptor Describe() {
+    TOpDescriptor d;
+    d.Class                = Traits::Class;
+    d.CreateDirsFromName   = Traits::CreateDirsFromName;
+    d.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
+    d.NeedRewrite          = Traits::NeedRewrite;
+    d.HasMakeOperationParts = requires {
+        Traits::MakeOperationParts(
+            std::declval<const TOperation&>(),
+            std::declval<const TTxTransaction&>(),
+            std::declval<TOperationContext&>());
+    };
+    d.HasCollectChangingPaths = requires {
+        Traits::CollectChangingPaths(
+            std::declval<const TTxTransaction&>(),
+            std::declval<TVector<TString>&>());
+    };
+    return d;
+}
 
 }  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -10,7 +10,7 @@
 #include <util/generic/string.h>
 
 #include <optional>
-#include <utility>  // std::declval, used by Describe<>()
+#include <utility>
 
 namespace NKikimr::NSchemeShard {
 
@@ -282,21 +282,13 @@ bool Rewrite(TTraits traits, TTxTransaction& tx) {
 
 bool IsCreatePathOperation(NKikimrSchemeOp::EOperationType op);
 
-// --- Trait description -----------------------------------------------------
-//
-// Materialized snapshot of the static-constexpr fields of a TSchemeTxTraits<>
-// specialization. Lives next to the trait itself so the trait header is the
-// single source of truth for "what an op-trait carries"; tooling (ss_tool,
-// docs codegen, etc.) consumes this struct instead of mirroring the field
-// list. When you add a field to TSchemeTxTraitsFallback, also add it here
-// and extend Describe() below; nothing else needs to change.
-
+// Runtime snapshot of TSchemeTxTraits<> fields. When you add a field to
+// TSchemeTxTraitsFallback, mirror it here and extend Describe() below.
 struct TOpDescriptor {
     EOperationClass Class = EOperationClass::Unknown;
     bool CreateDirsFromName = false;
     bool CreateAdditionalDirs = false;
     bool NeedRewrite = false;
-    // Derived: which of the per-op module static methods the trait declares.
     bool HasMakeOperationParts = false;
     bool HasCollectChangingPaths = false;
 };

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1363,10 +1363,9 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
     case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropUnsafe:
         return {CreateForceDropUnsafe(op.NextPartId(), tx)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable:
-        if (tx.GetCreateTable().HasCopyFromTable()) {
-            return CreateCopyTable(op.NextPartId(), tx, context); // Copy indexes table as well as common table
-        }
-        return {CreateNewTable(op.NextPartId(), tx)};
+        // Per-op module: see schemeshard__operation_create_table.cpp.
+        return TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::
+            MakeOperationParts(op, tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTable:
         return CreateConsistentAlterTable(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpSplitMergeTablePartitions:

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1350,11 +1350,7 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         const TTxTransaction& tx,
         TOperationContext& context) const
 {
-    // Per-op module path: dispatches via the generated DispatchOp switch to
-    // TSchemeTxTraits<op>. If the trait specialization defines
-    // MakeOperationParts, the module owns construction and we're done.
-    // Migrated ops are deleted from the legacy switch below; new ops should
-    // be added as per-op modules, not switch cases.
+    // Per-op module dispatch: trait owns construction if it provides the method.
     TVector<ISubOperation::TPtr> result;
     const bool handled = DispatchOp(tx, [&](auto traits) {
         using Traits = decltype(traits);
@@ -1380,8 +1376,6 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         return {CreateAlterUserAttrs(op.NextPartId(), tx)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropUnsafe:
         return {CreateForceDropUnsafe(op.NextPartId(), tx)};
-    // ESchemeOpCreateTable: owned by TSchemeTxTraits<ESchemeOpCreateTable>,
-    // see schemeshard__operation_create_table.cpp.
     case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTable:
         return CreateConsistentAlterTable(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpSplitMergeTablePartitions:

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1350,6 +1350,24 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         const TTxTransaction& tx,
         TOperationContext& context) const
 {
+    // Per-op module path: dispatches via the generated DispatchOp switch to
+    // TSchemeTxTraits<op>. If the trait specialization defines
+    // MakeOperationParts, the module owns construction and we're done.
+    // Migrated ops are deleted from the legacy switch below; new ops should
+    // be added as per-op modules, not switch cases.
+    TVector<ISubOperation::TPtr> result;
+    const bool handled = DispatchOp(tx, [&](auto traits) {
+        using Traits = decltype(traits);
+        if constexpr (requires { Traits::MakeOperationParts(op, tx, context); }) {
+            result = Traits::MakeOperationParts(op, tx, context);
+            return true;
+        }
+        return false;
+    });
+    if (handled) {
+        return result;
+    }
+
     const auto& opType = tx.GetOperationType();
     switch (opType) {
     case NKikimrSchemeOp::EOperationType::ESchemeOpMkDir:
@@ -1362,10 +1380,8 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         return {CreateAlterUserAttrs(op.NextPartId(), tx)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropUnsafe:
         return {CreateForceDropUnsafe(op.NextPartId(), tx)};
-    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable:
-        // Per-op module: see schemeshard__operation_create_table.cpp.
-        return TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::
-            MakeOperationParts(op, tx, context);
+    // ESchemeOpCreateTable: owned by TSchemeTxTraits<ESchemeOpCreateTable>,
+    // see schemeshard__operation_create_table.cpp.
     case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTable:
         return CreateConsistentAlterTable(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpSplitMergeTablePartitions:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -3,6 +3,7 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 
+#include <ydb/core/base/path.h>  // for NKikimr::JoinPath used by CollectChangingPaths
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>
 #include <ydb/core/protos/datashard_config.pb.h>
@@ -828,6 +829,35 @@ bool SetName<TTag>(
 }
 
 } // namespace NOperation
+
+// --- Per-op module: TSchemeTxTraits<ESchemeOpCreateTable> ---
+// Definitions for the static methods declared in schemeshard__op_traits.h.
+// Co-locating MakeOperationParts and CollectChangingPaths here makes this
+// file the single source of truth for everything CreateTable: trait flags,
+// classification, factory wiring, audit-path extraction, and target-name
+// accessors. The 5+ central switches that previously scattered this knowledge
+// just delegate to these methods.
+
+TVector<ISubOperation::TPtr>
+TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::MakeOperationParts(
+    const TOperation& op,
+    const TTxTransaction& tx,
+    TOperationContext& context)
+{
+    if (tx.GetCreateTable().HasCopyFromTable()) {
+        // Copy indexes table as well as common table.
+        return CreateCopyTable(op.NextPartId(), tx, context);
+    }
+    return {CreateNewTable(op.NextPartId(), tx)};
+}
+
+void
+TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::CollectChangingPaths(
+    const TTxTransaction& tx,
+    TVector<TString>& out)
+{
+    out.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreateTable().GetName()}));
+}
 
 ISubOperation::TPtr CreateNewTable(TOperationId id, const TTxTransaction& tx, const THashSet<TString>& localSequences) {
     auto obj = MakeSubOperation<TCreateTable>(id, tx);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -3,7 +3,7 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 
-#include <ydb/core/base/path.h>  // for NKikimr::JoinPath used by CollectChangingPaths
+#include <ydb/core/base/path.h>
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>
 #include <ydb/core/protos/datashard_config.pb.h>
@@ -830,14 +830,6 @@ bool SetName<TTag>(
 
 } // namespace NOperation
 
-// --- Per-op module: TSchemeTxTraits<ESchemeOpCreateTable> ---
-// Definitions for the static methods declared in schemeshard__op_traits.h.
-// Co-locating MakeOperationParts and CollectChangingPaths here makes this
-// file the single source of truth for everything CreateTable: trait flags,
-// classification, factory wiring, audit-path extraction, and target-name
-// accessors. The 5+ central switches that previously scattered this knowledge
-// just delegate to these methods.
-
 TVector<ISubOperation::TPtr>
 TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::MakeOperationParts(
     const TOperation& op,
@@ -845,7 +837,6 @@ TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::MakeOper
     TOperationContext& context)
 {
     if (tx.GetCreateTable().HasCopyFromTable()) {
-        // Copy indexes table as well as common table.
         return CreateCopyTable(op.NextPartId(), tx, context);
     }
     return {CreateNewTable(op.NextPartId(), tx)};

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -1,5 +1,7 @@
 #include "schemeshard_audit_log_fragment.h"
 
+#include "schemeshard__op_traits.h"
+
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/index_builder.pb.h>
@@ -322,7 +324,9 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetMkDir().GetName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable:
-        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreateTable().GetName()}));
+        // Per-op module: see schemeshard__operation_create_table.cpp.
+        TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::
+            CollectChangingPaths(tx, result);
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreatePersQueueGroup().GetName()}));

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -1,6 +1,6 @@
 #include "schemeshard_audit_log_fragment.h"
 
-#include "schemeshard__op_traits.h"
+#include "schemeshard__dispatch_op.h"
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
@@ -319,15 +319,29 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
 TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) {
     TVector<TString> result;
 
+    // Per-op module path: dispatches via the generated DispatchOp switch to
+    // TSchemeTxTraits<op>. If the trait specialization defines
+    // CollectChangingPaths, the module owns audit-path extraction and we're
+    // done. Migrated ops are deleted from the legacy switch below; new ops
+    // should be added as per-op modules, not switch cases.
+    const bool handled = DispatchOp(tx, [&](auto traits) {
+        using Traits = decltype(traits);
+        if constexpr (requires { Traits::CollectChangingPaths(tx, result); }) {
+            Traits::CollectChangingPaths(tx, result);
+            return true;
+        }
+        return false;
+    });
+    if (handled) {
+        return result;
+    }
+
     switch (tx.GetOperationType()) {
     case NKikimrSchemeOp::EOperationType::ESchemeOpMkDir:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetMkDir().GetName()}));
         break;
-    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable:
-        // Per-op module: see schemeshard__operation_create_table.cpp.
-        TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable>::
-            CollectChangingPaths(tx, result);
-        break;
+    // ESchemeOpCreateTable: owned by TSchemeTxTraits<ESchemeOpCreateTable>,
+    // see schemeshard__operation_create_table.cpp.
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreatePersQueueGroup().GetName()}));
         break;

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -319,11 +319,7 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
 TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) {
     TVector<TString> result;
 
-    // Per-op module path: dispatches via the generated DispatchOp switch to
-    // TSchemeTxTraits<op>. If the trait specialization defines
-    // CollectChangingPaths, the module owns audit-path extraction and we're
-    // done. Migrated ops are deleted from the legacy switch below; new ops
-    // should be added as per-op modules, not switch cases.
+    // Per-op module dispatch: trait owns extraction if it provides the method.
     const bool handled = DispatchOp(tx, [&](auto traits) {
         using Traits = decltype(traits);
         if constexpr (requires { Traits::CollectChangingPaths(tx, result); }) {
@@ -340,8 +336,6 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
     case NKikimrSchemeOp::EOperationType::ESchemeOpMkDir:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetMkDir().GetName()}));
         break;
-    // ESchemeOpCreateTable: owned by TSchemeTxTraits<ESchemeOpCreateTable>,
-    // see schemeshard__operation_create_table.cpp.
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreatePersQueueGroup().GetName()}));
         break;

--- a/ydb/core/tx/schemeshard/ut_op_traits/op_traits_ut.cpp
+++ b/ydb/core/tx/schemeshard/ut_op_traits/op_traits_ut.cpp
@@ -1,18 +1,3 @@
-// Unit tests for the schemeshard per-op trait module pattern (CreateTable
-// pilot). What this PR introduced and what these tests pin down:
-//
-//   1. EOperationClass lifted into the trait header so trait specs can
-//      carry classification at compile time.
-//   2. TSchemeTxTraits<ESchemeOpCreateTable> declares Class=Create plus the
-//      static methods MakeOperationParts and CollectChangingPaths.
-//   3. The audit-log dispatch (MakeAuditLogFragment / ExtractChangingPaths)
-//      starts with a DispatchOp prelude that routes CreateTable through the
-//      trait method; the central switch case for CreateTable is gone.
-//   4. Unmigrated ops still flow through the legacy switch — both for
-//      audit-path extraction and for GetOperationClass.
-//   5. Describe<Traits>() is the single source of truth for the
-//      materialized trait shape consumed by tooling.
-
 #include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
 #include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
 #include <ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h>
@@ -24,66 +9,28 @@
 using namespace NKikimr::NSchemeShard;
 namespace NSO = NKikimrSchemeOp;
 
-// --- Compile-time facts --------------------------------------------------
-//
-// These are the invariants the per-op pilot adds to the trait system. If a
-// future change breaks any of them the file simply won't compile, which is
-// the strongest possible regression guard.
-
-static_assert(
-    TSchemeTxTraitsFallback::Class == EOperationClass::Unknown,
-    "Fallback trait must default Class to Unknown");
-
-static_assert(
-    TSchemeTxTraits<NSO::ESchemeOpCreateTable>::Class == EOperationClass::Create,
-    "CreateTable trait must declare Class=Create");
-
-static_assert(
-    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().Class == EOperationClass::Create,
-    "Describe<>() must report Class for migrated ops");
-
-static_assert(
-    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasMakeOperationParts,
-    "CreateTable trait must declare MakeOperationParts");
-
-static_assert(
-    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasCollectChangingPaths,
-    "CreateTable trait must declare CollectChangingPaths");
-
-static_assert(
-    !Describe<TSchemeTxTraits<NSO::ESchemeOpMkDir>>().HasMakeOperationParts,
-    "MkDir is not migrated; trait must not advertise MakeOperationParts");
-
-static_assert(
-    !Describe<TSchemeTxTraits<NSO::ESchemeOpDropTable>>().HasCollectChangingPaths,
-    "DropTable is not migrated; trait must not advertise CollectChangingPaths");
-
-// --- Runtime tests -------------------------------------------------------
+static_assert(TSchemeTxTraitsFallback::Class == EOperationClass::Unknown);
+static_assert(TSchemeTxTraits<NSO::ESchemeOpCreateTable>::Class == EOperationClass::Create);
+static_assert(Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasMakeOperationParts);
+static_assert(Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasCollectChangingPaths);
+static_assert(!Describe<TSchemeTxTraits<NSO::ESchemeOpMkDir>>().HasMakeOperationParts);
+static_assert(!Describe<TSchemeTxTraits<NSO::ESchemeOpDropTable>>().HasCollectChangingPaths);
 
 Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
 
     Y_UNIT_TEST(GetOperationClassReturnsCreateForCreateTable) {
-        // Legacy switch must still classify CreateTable correctly. Parity
-        // with the trait's Class is enforced by the static_assert in
-        // schemeshard__op_traits.cpp.
         UNIT_ASSERT_EQUAL(GetOperationClass(NSO::ESchemeOpCreateTable),
                           EOperationClass::Create);
         UNIT_ASSERT(IsCreatePathOperation(NSO::ESchemeOpCreateTable));
     }
 
     Y_UNIT_TEST(GetOperationClassReturnsDropForDropTable) {
-        // DropTable hasn't migrated yet — the legacy switch is the source
-        // of truth here. Trait Class is intentionally Unknown until DropTable
-        // moves to the per-op module pattern.
         UNIT_ASSERT_EQUAL(GetOperationClass(NSO::ESchemeOpDropTable),
                           EOperationClass::Drop);
         UNIT_ASSERT(!IsCreatePathOperation(NSO::ESchemeOpDropTable));
     }
 
     Y_UNIT_TEST(CollectChangingPathsForCreateTableProducesExpectedPath) {
-        // Direct call to the trait's static method. Verifies the per-op
-        // module owns the correct logic in isolation, independent of
-        // dispatch.
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpCreateTable);
         tx.SetWorkingDir("/Root/Db");
@@ -97,10 +44,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(MakeAuditLogFragmentRoutesCreateTableThroughTrait) {
-        // End-to-end: the public audit API still produces the correct
-        // Paths for CreateTable after the central switch case was deleted
-        // in favor of the DispatchOp prelude. If routing breaks (trait
-        // method not invoked), Paths would be empty.
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpCreateTable);
         tx.SetWorkingDir("/Root/Db");
@@ -112,8 +55,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(MakeAuditLogFragmentStillHandlesUnmigratedOps) {
-        // MkDir hasn't migrated and must keep flowing through the legacy
-        // switch. Catches accidental over-deletion of switch cases.
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpMkDir);
         tx.SetWorkingDir("/Root");
@@ -125,9 +66,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(MakeAuditLogFragmentHandlesCopyFromTableVariant) {
-        // CreateTable with CopyFromTable set: the trait method should still
-        // surface the destination path under WorkingDir/Name (matching the
-        // pre-refactor inline code).
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpCreateTable);
         tx.SetWorkingDir("/Root/Db");
@@ -141,9 +79,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(DispatchOpInstantiatesTheRightTraitForCreateTable) {
-        // Verify the existing DispatchOp routes CreateTable to its
-        // specialization (the one carrying Class=Create), not to the
-        // fallback type.
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpCreateTable);
 
@@ -154,11 +89,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(DispatchOpRoutesUnmigratedOpToOwnSpec) {
-        // For an unmigrated op like DropTable the dispatch still hits the
-        // op-specific TSchemeTxTraits<DropTable> spec (which inherits
-        // Class=Unknown from the fallback) — NOT the fallback type itself.
-        // This pins down the pattern that lets new fields default safely
-        // to fallback values per-op.
         NSO::TModifyScheme tx;
         tx.SetOperationType(NSO::ESchemeOpDropTable);
 
@@ -169,10 +99,6 @@ Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
     }
 
     Y_UNIT_TEST(DescribeReportsCreateTableTraitFlags) {
-        // Sanity: Describe<>() surfaces both the explicit fields
-        // (CreateDirsFromName) and the derived 'Has*' fields. Tooling
-        // (ss_tool) consumes these; the contract should not silently
-        // change shape.
         constexpr auto d = Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>();
         UNIT_ASSERT_EQUAL(d.Class, EOperationClass::Create);
         UNIT_ASSERT(d.CreateDirsFromName);

--- a/ydb/core/tx/schemeshard/ut_op_traits/op_traits_ut.cpp
+++ b/ydb/core/tx/schemeshard/ut_op_traits/op_traits_ut.cpp
@@ -1,0 +1,184 @@
+// Unit tests for the schemeshard per-op trait module pattern (CreateTable
+// pilot). What this PR introduced and what these tests pin down:
+//
+//   1. EOperationClass lifted into the trait header so trait specs can
+//      carry classification at compile time.
+//   2. TSchemeTxTraits<ESchemeOpCreateTable> declares Class=Create plus the
+//      static methods MakeOperationParts and CollectChangingPaths.
+//   3. The audit-log dispatch (MakeAuditLogFragment / ExtractChangingPaths)
+//      starts with a DispatchOp prelude that routes CreateTable through the
+//      trait method; the central switch case for CreateTable is gone.
+//   4. Unmigrated ops still flow through the legacy switch — both for
+//      audit-path extraction and for GetOperationClass.
+//   5. Describe<Traits>() is the single source of truth for the
+//      materialized trait shape consumed by tooling.
+
+#include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
+#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
+#include <ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h>
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr::NSchemeShard;
+namespace NSO = NKikimrSchemeOp;
+
+// --- Compile-time facts --------------------------------------------------
+//
+// These are the invariants the per-op pilot adds to the trait system. If a
+// future change breaks any of them the file simply won't compile, which is
+// the strongest possible regression guard.
+
+static_assert(
+    TSchemeTxTraitsFallback::Class == EOperationClass::Unknown,
+    "Fallback trait must default Class to Unknown");
+
+static_assert(
+    TSchemeTxTraits<NSO::ESchemeOpCreateTable>::Class == EOperationClass::Create,
+    "CreateTable trait must declare Class=Create");
+
+static_assert(
+    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().Class == EOperationClass::Create,
+    "Describe<>() must report Class for migrated ops");
+
+static_assert(
+    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasMakeOperationParts,
+    "CreateTable trait must declare MakeOperationParts");
+
+static_assert(
+    Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>().HasCollectChangingPaths,
+    "CreateTable trait must declare CollectChangingPaths");
+
+static_assert(
+    !Describe<TSchemeTxTraits<NSO::ESchemeOpMkDir>>().HasMakeOperationParts,
+    "MkDir is not migrated; trait must not advertise MakeOperationParts");
+
+static_assert(
+    !Describe<TSchemeTxTraits<NSO::ESchemeOpDropTable>>().HasCollectChangingPaths,
+    "DropTable is not migrated; trait must not advertise CollectChangingPaths");
+
+// --- Runtime tests -------------------------------------------------------
+
+Y_UNIT_TEST_SUITE(SchemeshardOpTraits) {
+
+    Y_UNIT_TEST(GetOperationClassReturnsCreateForCreateTable) {
+        // Legacy switch must still classify CreateTable correctly. Parity
+        // with the trait's Class is enforced by the static_assert in
+        // schemeshard__op_traits.cpp.
+        UNIT_ASSERT_EQUAL(GetOperationClass(NSO::ESchemeOpCreateTable),
+                          EOperationClass::Create);
+        UNIT_ASSERT(IsCreatePathOperation(NSO::ESchemeOpCreateTable));
+    }
+
+    Y_UNIT_TEST(GetOperationClassReturnsDropForDropTable) {
+        // DropTable hasn't migrated yet — the legacy switch is the source
+        // of truth here. Trait Class is intentionally Unknown until DropTable
+        // moves to the per-op module pattern.
+        UNIT_ASSERT_EQUAL(GetOperationClass(NSO::ESchemeOpDropTable),
+                          EOperationClass::Drop);
+        UNIT_ASSERT(!IsCreatePathOperation(NSO::ESchemeOpDropTable));
+    }
+
+    Y_UNIT_TEST(CollectChangingPathsForCreateTableProducesExpectedPath) {
+        // Direct call to the trait's static method. Verifies the per-op
+        // module owns the correct logic in isolation, independent of
+        // dispatch.
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpCreateTable);
+        tx.SetWorkingDir("/Root/Db");
+        tx.MutableCreateTable()->SetName("Users");
+
+        TVector<TString> paths;
+        TSchemeTxTraits<NSO::ESchemeOpCreateTable>::CollectChangingPaths(tx, paths);
+
+        UNIT_ASSERT_VALUES_EQUAL(paths.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(paths[0], "/Root/Db/Users");
+    }
+
+    Y_UNIT_TEST(MakeAuditLogFragmentRoutesCreateTableThroughTrait) {
+        // End-to-end: the public audit API still produces the correct
+        // Paths for CreateTable after the central switch case was deleted
+        // in favor of the DispatchOp prelude. If routing breaks (trait
+        // method not invoked), Paths would be empty.
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpCreateTable);
+        tx.SetWorkingDir("/Root/Db");
+        tx.MutableCreateTable()->SetName("Users");
+
+        const auto fragment = MakeAuditLogFragment(tx);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths[0], "/Root/Db/Users");
+    }
+
+    Y_UNIT_TEST(MakeAuditLogFragmentStillHandlesUnmigratedOps) {
+        // MkDir hasn't migrated and must keep flowing through the legacy
+        // switch. Catches accidental over-deletion of switch cases.
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpMkDir);
+        tx.SetWorkingDir("/Root");
+        tx.MutableMkDir()->SetName("NewDir");
+
+        const auto fragment = MakeAuditLogFragment(tx);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths[0], "/Root/NewDir");
+    }
+
+    Y_UNIT_TEST(MakeAuditLogFragmentHandlesCopyFromTableVariant) {
+        // CreateTable with CopyFromTable set: the trait method should still
+        // surface the destination path under WorkingDir/Name (matching the
+        // pre-refactor inline code).
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpCreateTable);
+        tx.SetWorkingDir("/Root/Db");
+        auto* createTable = tx.MutableCreateTable();
+        createTable->SetName("UsersCopy");
+        createTable->SetCopyFromTable("/Root/Db/Users");
+
+        const auto fragment = MakeAuditLogFragment(tx);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(fragment.Paths[0], "/Root/Db/UsersCopy");
+    }
+
+    Y_UNIT_TEST(DispatchOpInstantiatesTheRightTraitForCreateTable) {
+        // Verify the existing DispatchOp routes CreateTable to its
+        // specialization (the one carrying Class=Create), not to the
+        // fallback type.
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpCreateTable);
+
+        const auto cls = DispatchOp(tx, [](auto traits) {
+            return decltype(traits)::Class;
+        });
+        UNIT_ASSERT_EQUAL(cls, EOperationClass::Create);
+    }
+
+    Y_UNIT_TEST(DispatchOpRoutesUnmigratedOpToOwnSpec) {
+        // For an unmigrated op like DropTable the dispatch still hits the
+        // op-specific TSchemeTxTraits<DropTable> spec (which inherits
+        // Class=Unknown from the fallback) — NOT the fallback type itself.
+        // This pins down the pattern that lets new fields default safely
+        // to fallback values per-op.
+        NSO::TModifyScheme tx;
+        tx.SetOperationType(NSO::ESchemeOpDropTable);
+
+        const auto cls = DispatchOp(tx, [](auto traits) {
+            return decltype(traits)::Class;
+        });
+        UNIT_ASSERT_EQUAL(cls, EOperationClass::Unknown);
+    }
+
+    Y_UNIT_TEST(DescribeReportsCreateTableTraitFlags) {
+        // Sanity: Describe<>() surfaces both the explicit fields
+        // (CreateDirsFromName) and the derived 'Has*' fields. Tooling
+        // (ss_tool) consumes these; the contract should not silently
+        // change shape.
+        constexpr auto d = Describe<TSchemeTxTraits<NSO::ESchemeOpCreateTable>>();
+        UNIT_ASSERT_EQUAL(d.Class, EOperationClass::Create);
+        UNIT_ASSERT(d.CreateDirsFromName);
+        UNIT_ASSERT(!d.CreateAdditionalDirs);
+        UNIT_ASSERT(!d.NeedRewrite);
+        UNIT_ASSERT(d.HasMakeOperationParts);
+        UNIT_ASSERT(d.HasCollectChangingPaths);
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_op_traits/ya.make
+++ b/ydb/core/tx/schemeshard/ut_op_traits/ya.make
@@ -1,0 +1,13 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+SIZE(SMALL)
+
+PEERDIR(
+    ydb/core/protos
+)
+
+SRCS(
+    op_traits_ut.cpp
+)
+
+END()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -42,6 +42,7 @@ RECURSE_FOR_TESTS(
     ut_move_reboots
     ut_olap
     ut_olap_reboots
+    ut_op_traits
     ut_partition_stats
     ut_pq_reboots
     ut_reboots

--- a/ydb/tools/ss_tool/lib/op_inspect.cpp
+++ b/ydb/tools/ss_tool/lib/op_inspect.cpp
@@ -1,0 +1,60 @@
+#include "op_inspect.h"
+
+#include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
+
+#include <util/generic/hash_set.h>
+
+namespace NKikimr::NSchemeShard::NSsTool {
+
+TStringBuf ClassName(EOperationClass c) {
+    switch (c) {
+        case EOperationClass::Create:  return "Create";
+        case EOperationClass::Alter:   return "Alter";
+        case EOperationClass::Drop:    return "Drop";
+        case EOperationClass::Other:   return "Other";
+        case EOperationClass::Unknown: return "Unknown";
+    }
+    return "?";
+}
+
+TOpRow CollectRow(NKikimrSchemeOp::EOperationType opType) {
+    TOpRow row;
+    row.Type = opType;
+    row.Name = NKikimrSchemeOp::EOperationType_Name(opType);
+
+    // DispatchOp routes by tx.GetOperationType(); feed it a synthetic tx and
+    // hand the matched trait type to NSchemeShard::Describe<>().
+    NKikimrSchemeOp::TModifyScheme tx;
+    tx.SetOperationType(opType);
+    DispatchOp(tx, [&](auto traits) {
+        row.Desc = Describe<decltype(traits)>();
+    });
+
+    return row;
+}
+
+TVector<TOpRow> AllOps() {
+    TVector<TOpRow> result;
+    THashSet<int> seen;
+    const auto* d = NKikimrSchemeOp::EOperationType_descriptor();
+    for (int i = 0; i < d->value_count(); ++i) {
+        const auto* v = d->value(i);
+        if (!seen.insert(v->number()).second) {
+            continue; // proto enum may carry aliases sharing one number
+        }
+        result.push_back(CollectRow(static_cast<NKikimrSchemeOp::EOperationType>(v->number())));
+    }
+    return result;
+}
+
+bool MethodKnown(const TString& name) {
+    return name == "MakeOperationParts" || name == "CollectChangingPaths";
+}
+
+bool HasMethod(const TOpDescriptor& d, const TString& name) {
+    if (name == "MakeOperationParts")   return d.HasMakeOperationParts;
+    if (name == "CollectChangingPaths") return d.HasCollectChangingPaths;
+    return false;
+}
+
+} // namespace NKikimr::NSchemeShard::NSsTool

--- a/ydb/tools/ss_tool/lib/op_inspect.cpp
+++ b/ydb/tools/ss_tool/lib/op_inspect.cpp
@@ -22,8 +22,6 @@ TOpRow CollectRow(NKikimrSchemeOp::EOperationType opType) {
     row.Type = opType;
     row.Name = NKikimrSchemeOp::EOperationType_Name(opType);
 
-    // DispatchOp routes by tx.GetOperationType(); feed it a synthetic tx and
-    // hand the matched trait type to NSchemeShard::Describe<>().
     NKikimrSchemeOp::TModifyScheme tx;
     tx.SetOperationType(opType);
     DispatchOp(tx, [&](auto traits) {
@@ -35,12 +33,12 @@ TOpRow CollectRow(NKikimrSchemeOp::EOperationType opType) {
 
 TVector<TOpRow> AllOps() {
     TVector<TOpRow> result;
-    THashSet<int> seen;
+    THashSet<int> seen; // proto enum may carry aliases sharing one number
     const auto* d = NKikimrSchemeOp::EOperationType_descriptor();
     for (int i = 0; i < d->value_count(); ++i) {
         const auto* v = d->value(i);
         if (!seen.insert(v->number()).second) {
-            continue; // proto enum may carry aliases sharing one number
+            continue;
         }
         result.push_back(CollectRow(static_cast<NKikimrSchemeOp::EOperationType>(v->number())));
     }

--- a/ydb/tools/ss_tool/lib/op_inspect.h
+++ b/ydb/tools/ss_tool/lib/op_inspect.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
+
+#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+#include <util/generic/vector.h>
+
+namespace NKikimr::NSchemeShard::NSsTool {
+
+// One row in ss_tool's tables: identity (name + enum number) plus the
+// trait-derived metadata. Identity is purely runtime info that does not
+// belong on the trait; the rest is mirrored from TOpDescriptor in
+// schemeshard__op_traits.h, which is the single source of truth for trait
+// fields.
+struct TOpRow {
+    TString Name;
+    NKikimrSchemeOp::EOperationType Type{};
+    TOpDescriptor Desc;
+};
+
+// Pretty-print an operation class enum.
+TStringBuf ClassName(EOperationClass c);
+
+// Read TOpDescriptor for a single op type via the existing DispatchOp +
+// Describe<>() infrastructure. Pure: same input -> same output.
+TOpRow CollectRow(NKikimrSchemeOp::EOperationType opType);
+
+// Enumerate every op type from the proto descriptor (deduplicating aliases
+// that share an enum number) and collect a row for each.
+TVector<TOpRow> AllOps();
+
+// Whether NAME is one of the per-op module method names ss_tool understands
+// for filtering. Used to validate --has / --missing arguments.
+bool MethodKnown(const TString& name);
+
+// Lookup the per-op-method bool on a descriptor by name. Returns false for
+// unknown names (callers are expected to have validated via MethodKnown).
+bool HasMethod(const TOpDescriptor& d, const TString& name);
+
+} // namespace NKikimr::NSchemeShard::NSsTool

--- a/ydb/tools/ss_tool/lib/op_inspect.h
+++ b/ydb/tools/ss_tool/lib/op_inspect.h
@@ -9,34 +9,17 @@
 
 namespace NKikimr::NSchemeShard::NSsTool {
 
-// One row in ss_tool's tables: identity (name + enum number) plus the
-// trait-derived metadata. Identity is purely runtime info that does not
-// belong on the trait; the rest is mirrored from TOpDescriptor in
-// schemeshard__op_traits.h, which is the single source of truth for trait
-// fields.
 struct TOpRow {
     TString Name;
     NKikimrSchemeOp::EOperationType Type{};
     TOpDescriptor Desc;
 };
 
-// Pretty-print an operation class enum.
 TStringBuf ClassName(EOperationClass c);
-
-// Read TOpDescriptor for a single op type via the existing DispatchOp +
-// Describe<>() infrastructure. Pure: same input -> same output.
 TOpRow CollectRow(NKikimrSchemeOp::EOperationType opType);
-
-// Enumerate every op type from the proto descriptor (deduplicating aliases
-// that share an enum number) and collect a row for each.
 TVector<TOpRow> AllOps();
 
-// Whether NAME is one of the per-op module method names ss_tool understands
-// for filtering. Used to validate --has / --missing arguments.
 bool MethodKnown(const TString& name);
-
-// Lookup the per-op-method bool on a descriptor by name. Returns false for
-// unknown names (callers are expected to have validated via MethodKnown).
 bool HasMethod(const TOpDescriptor& d, const TString& name);
 
 } // namespace NKikimr::NSchemeShard::NSsTool

--- a/ydb/tools/ss_tool/lib/ya.make
+++ b/ydb/tools/ss_tool/lib/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    op_inspect.cpp
+)
+
+PEERDIR(
+    ydb/core/protos
+    ydb/core/tx/schemeshard
+)
+
+END()

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -1,0 +1,270 @@
+// ss_tool — read-only inspector for the schemeshard operation trait system.
+//
+// The schemeshard trait registry (TSchemeTxTraits<EOperationType>) carries
+// per-op metadata at compile time. The per-op `.cpp` view ("show me everything
+// about CreateTable") lives in the source. This tool exposes the orthogonal
+// by-aspect view ("show me all Create-class ops", "show me ops that still
+// lack CollectChangingPaths") by iterating the proto enum and reading the
+// trait fields via the existing DispatchOp infrastructure.
+
+#include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
+#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+
+#include <library/cpp/getopt/last_getopt.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/stream/output.h>
+#include <util/string/builder.h>
+
+#include <utility>
+
+namespace {
+
+using namespace NKikimr::NSchemeShard;
+namespace NSO = NKikimrSchemeOp;
+
+// Snapshot of the metadata we read out of TSchemeTxTraits<op>. Extend this
+// struct (and CollectInfo below) when new trait fields land.
+struct TOpInfo {
+    TString Name;
+    NSO::EOperationType Type{};
+    EOperationClass Class = EOperationClass::Unknown;
+    bool CreateDirsFromName = false;
+    bool CreateAdditionalDirs = false;
+    bool NeedRewrite = false;
+    bool HasMakeOperationParts = false;
+    bool HasCollectChangingPaths = false;
+};
+
+TStringBuf ClassName(EOperationClass c) {
+    switch (c) {
+        case EOperationClass::Create:  return "Create";
+        case EOperationClass::Alter:   return "Alter";
+        case EOperationClass::Drop:    return "Drop";
+        case EOperationClass::Other:   return "Other";
+        case EOperationClass::Unknown: return "Unknown";
+    }
+    return "?";
+}
+
+TOpInfo CollectInfo(NSO::EOperationType opType) {
+    TOpInfo info;
+    info.Type = opType;
+    info.Name = NSO::EOperationType_Name(opType);
+
+    // DispatchOp routes by tx.GetOperationType(); we feed it a synthetic tx.
+    NSO::TModifyScheme tx;
+    tx.SetOperationType(opType);
+
+    DispatchOp(tx, [&](auto traits) {
+        using Traits = decltype(traits);
+        info.Class = Traits::Class;
+        info.CreateDirsFromName = Traits::CreateDirsFromName;
+        info.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
+        info.NeedRewrite = Traits::NeedRewrite;
+        info.HasMakeOperationParts = requires {
+            Traits::MakeOperationParts(
+                std::declval<const TOperation&>(),
+                std::declval<const TTxTransaction&>(),
+                std::declval<TOperationContext&>());
+        };
+        info.HasCollectChangingPaths = requires {
+            Traits::CollectChangingPaths(
+                std::declval<const TTxTransaction&>(),
+                std::declval<TVector<TString>&>());
+        };
+    });
+
+    return info;
+}
+
+TVector<TOpInfo> AllOps() {
+    TVector<TOpInfo> result;
+    THashSet<int> seen;
+    const auto* d = NSO::EOperationType_descriptor();
+    for (int i = 0; i < d->value_count(); ++i) {
+        const auto* v = d->value(i);
+        if (!seen.insert(v->number()).second) {
+            continue; // proto enum may carry aliases sharing one number
+        }
+        result.push_back(CollectInfo(static_cast<NSO::EOperationType>(v->number())));
+    }
+    return result;
+}
+
+TString FormatFlags(const TOpInfo& op) {
+    TStringBuilder sb;
+    auto add = [&](const char* tag) {
+        if (sb.size() > 0) {
+            sb << ",";
+        }
+        sb << tag;
+    };
+    if (op.CreateDirsFromName)   add("CreateDirsFromName");
+    if (op.CreateAdditionalDirs) add("CreateAdditionalDirs");
+    if (op.NeedRewrite)          add("NeedRewrite");
+    return sb;
+}
+
+void PrintHeader() {
+    Cout << "NAME"
+         << "\tCLASS"
+         << "\tMakeOperationParts"
+         << "\tCollectChangingPaths"
+         << "\tFLAGS"
+         << Endl;
+}
+
+void PrintRow(const TOpInfo& op) {
+    Cout << op.Name
+         << "\t" << ClassName(op.Class)
+         << "\t" << (op.HasMakeOperationParts   ? "yes" : "no")
+         << "\t" << (op.HasCollectChangingPaths ? "yes" : "no")
+         << "\t" << FormatFlags(op)
+         << Endl;
+}
+
+bool MethodKnown(const TString& name) {
+    return name == "MakeOperationParts" || name == "CollectChangingPaths";
+}
+
+bool HasMethod(const TOpInfo& op, const TString& name) {
+    if (name == "MakeOperationParts")   return op.HasMakeOperationParts;
+    if (name == "CollectChangingPaths") return op.HasCollectChangingPaths;
+    return false;
+}
+
+int CmdList(int argc, const char** argv) {
+    TString classFilter;
+    TString hasFilter;
+    TString missingFilter;
+
+    NLastGetopt::TOpts opts;
+    opts.AddLongOption("class", "filter by class: Create|Alter|Drop|Other|Unknown")
+        .StoreResult(&classFilter);
+    opts.AddLongOption("has", "only ops whose trait defines METHOD")
+        .StoreResult(&hasFilter);
+    opts.AddLongOption("missing", "only ops whose trait does NOT define METHOD")
+        .StoreResult(&missingFilter);
+    opts.AddHelpOption();
+    NLastGetopt::TOptsParseResult res(&opts, argc, argv);
+
+    if (!hasFilter.empty() && !MethodKnown(hasFilter)) {
+        Cerr << "Unknown method '" << hasFilter
+             << "'; expected MakeOperationParts or CollectChangingPaths" << Endl;
+        return 1;
+    }
+    if (!missingFilter.empty() && !MethodKnown(missingFilter)) {
+        Cerr << "Unknown method '" << missingFilter
+             << "'; expected MakeOperationParts or CollectChangingPaths" << Endl;
+        return 1;
+    }
+
+    PrintHeader();
+    for (const auto& op : AllOps()) {
+        if (!classFilter.empty() && TStringBuf(ClassName(op.Class)) != classFilter) {
+            continue;
+        }
+        if (!hasFilter.empty() && !HasMethod(op, hasFilter)) {
+            continue;
+        }
+        if (!missingFilter.empty() && HasMethod(op, missingFilter)) {
+            continue;
+        }
+        PrintRow(op);
+    }
+    return 0;
+}
+
+int CmdShow(int argc, const char** argv) {
+    if (argc < 2) {
+        Cerr << "Usage: ss_tool ops show <OpName>" << Endl;
+        return 1;
+    }
+    NSO::EOperationType opType{};
+    if (!NSO::EOperationType_Parse(argv[1], &opType)) {
+        Cerr << "Unknown op: " << argv[1] << Endl;
+        return 1;
+    }
+    auto info = CollectInfo(opType);
+    Cout << "Name:                     " << info.Name << Endl;
+    Cout << "Number:                   " << static_cast<int>(info.Type) << Endl;
+    Cout << "Class:                    " << ClassName(info.Class) << Endl;
+    Cout << "CreateDirsFromName:       " << (info.CreateDirsFromName   ? "true" : "false") << Endl;
+    Cout << "CreateAdditionalDirs:     " << (info.CreateAdditionalDirs ? "true" : "false") << Endl;
+    Cout << "NeedRewrite:              " << (info.NeedRewrite          ? "true" : "false") << Endl;
+    Cout << "HasMakeOperationParts:    " << (info.HasMakeOperationParts   ? "true" : "false") << Endl;
+    Cout << "HasCollectChangingPaths:  " << (info.HasCollectChangingPaths ? "true" : "false") << Endl;
+    return 0;
+}
+
+int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
+    auto ops = AllOps();
+    size_t total = ops.size();
+    size_t fullyMigrated = 0;
+    size_t partial = 0;
+    for (const auto& op : ops) {
+        if (op.HasMakeOperationParts && op.HasCollectChangingPaths) {
+            ++fullyMigrated;
+        } else if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+            ++partial;
+        }
+    }
+    Cout << "Total ops:      " << total << Endl;
+    Cout << "Fully migrated: " << fullyMigrated
+         << "  (trait defines both MakeOperationParts and CollectChangingPaths)" << Endl;
+    Cout << "Partial:        " << partial << Endl;
+    Cout << "Pending:        " << (total - fullyMigrated - partial) << Endl;
+    Cout << Endl;
+
+    Cout << "Pending ops grouped by Class:" << Endl;
+    THashMap<EOperationClass, TVector<const TOpInfo*>> byClass;
+    for (const auto& op : ops) {
+        if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+            continue;
+        }
+        byClass[op.Class].push_back(&op);
+    }
+    for (auto cls : {EOperationClass::Create, EOperationClass::Alter,
+                     EOperationClass::Drop,   EOperationClass::Other,
+                     EOperationClass::Unknown}) {
+        const auto& list = byClass[cls];
+        if (list.empty()) {
+            continue;
+        }
+        Cout << "  " << ClassName(cls) << " (" << list.size() << "):" << Endl;
+        for (const auto* op : list) {
+            Cout << "    " << op->Name << Endl;
+        }
+    }
+    return 0;
+}
+
+void PrintUsage(const char* argv0) {
+    Cerr << "Usage: " << argv0 << " ops <subcommand> [args...]" << Endl;
+    Cerr << "Subcommands:" << Endl;
+    Cerr << "  list [--class=X] [--has=METHOD] [--missing=METHOD]" << Endl;
+    Cerr << "  show <OpName>" << Endl;
+    Cerr << "  migration-status" << Endl;
+}
+
+} // namespace
+
+int main(int argc, const char** argv) {
+    if (argc < 3 || TString(argv[1]) != "ops") {
+        PrintUsage(argv[0]);
+        return 1;
+    }
+    const TString sub = argv[2];
+    if (sub == "list")             return CmdList(argc - 2, argv + 2);
+    if (sub == "show")             return CmdShow(argc - 2, argv + 2);
+    if (sub == "migration-status") return CmdMigrationStatus(argc - 2, argv + 2);
+    PrintUsage(argv[0]);
+    return 1;
+}

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -4,83 +4,23 @@
 // per-op metadata at compile time. The per-op `.cpp` view ("show me everything
 // about CreateTable") lives in the source. This tool exposes the orthogonal
 // by-aspect view ("show me all Create-class ops", "show me ops that still
-// lack CollectChangingPaths") by iterating the proto enum and reading the
-// trait fields via the existing DispatchOp infrastructure.
+// lack CollectChangingPaths") via the testable helpers in lib/op_inspect.
 
-#include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
-#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
-
-#include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/tools/ss_tool/lib/op_inspect.h>
 
 #include <library/cpp/getopt/last_getopt.h>
 
 #include <util/generic/hash.h>
-#include <util/generic/hash_set.h>
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 #include <util/stream/output.h>
 #include <util/string/builder.h>
 
-#include <utility>
-
 namespace {
 
 using namespace NKikimr::NSchemeShard;
+using namespace NKikimr::NSchemeShard::NSsTool;
 namespace NSO = NKikimrSchemeOp;
-
-// One row in the tool's tables: identity (name + enum number) plus the
-// trait-derived metadata. Identity is purely runtime info that does not
-// belong on the trait; the rest is mirrored from TOpDescriptor in
-// schemeshard__op_traits.h, which is the single source of truth for trait
-// fields. Extending the trait does NOT require changing this file unless we
-// want to expose the new field in `ops list` formatting.
-struct TOpRow {
-    TString Name;
-    NSO::EOperationType Type{};
-    TOpDescriptor Desc;
-};
-
-TStringBuf ClassName(EOperationClass c) {
-    switch (c) {
-        case EOperationClass::Create:  return "Create";
-        case EOperationClass::Alter:   return "Alter";
-        case EOperationClass::Drop:    return "Drop";
-        case EOperationClass::Other:   return "Other";
-        case EOperationClass::Unknown: return "Unknown";
-    }
-    return "?";
-}
-
-TOpRow CollectRow(NSO::EOperationType opType) {
-    TOpRow row;
-    row.Type = opType;
-    row.Name = NSO::EOperationType_Name(opType);
-
-    // DispatchOp routes by tx.GetOperationType(); feed it a synthetic tx and
-    // hand the matched trait type to NSchemeShard::Describe<>().
-    NSO::TModifyScheme tx;
-    tx.SetOperationType(opType);
-    DispatchOp(tx, [&](auto traits) {
-        row.Desc = Describe<decltype(traits)>();
-    });
-
-    return row;
-}
-
-TVector<TOpRow> AllOps() {
-    TVector<TOpRow> result;
-    THashSet<int> seen;
-    const auto* d = NSO::EOperationType_descriptor();
-    for (int i = 0; i < d->value_count(); ++i) {
-        const auto* v = d->value(i);
-        if (!seen.insert(v->number()).second) {
-            continue; // proto enum may carry aliases sharing one number
-        }
-        result.push_back(CollectRow(static_cast<NSO::EOperationType>(v->number())));
-    }
-    return result;
-}
 
 TString FormatFlags(const TOpDescriptor& d) {
     TStringBuilder sb;
@@ -112,16 +52,6 @@ void PrintRow(const TOpRow& op) {
          << "\t" << (op.Desc.HasCollectChangingPaths ? "yes" : "no")
          << "\t" << FormatFlags(op.Desc)
          << Endl;
-}
-
-bool MethodKnown(const TString& name) {
-    return name == "MakeOperationParts" || name == "CollectChangingPaths";
-}
-
-bool HasMethod(const TOpDescriptor& d, const TString& name) {
-    if (name == "MakeOperationParts")   return d.HasMakeOperationParts;
-    if (name == "CollectChangingPaths") return d.HasCollectChangingPaths;
-    return false;
 }
 
 int CmdList(int argc, const char** argv) {

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -1,10 +1,4 @@
-// ss_tool — read-only inspector for the schemeshard operation trait system.
-//
-// The schemeshard trait registry (TSchemeTxTraits<EOperationType>) carries
-// per-op metadata at compile time. The per-op `.cpp` view ("show me everything
-// about CreateTable") lives in the source. This tool exposes the orthogonal
-// by-aspect view ("show me all Create-class ops", "show me ops that still
-// lack CollectChangingPaths") via the testable helpers in lib/op_inspect.
+// Read-only inspector for the schemeshard operation trait system.
 
 #include <ydb/tools/ss_tool/lib/op_inspect.h>
 

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -29,17 +29,16 @@ namespace {
 using namespace NKikimr::NSchemeShard;
 namespace NSO = NKikimrSchemeOp;
 
-// Snapshot of the metadata we read out of TSchemeTxTraits<op>. Extend this
-// struct (and CollectInfo below) when new trait fields land.
-struct TOpInfo {
+// One row in the tool's tables: identity (name + enum number) plus the
+// trait-derived metadata. Identity is purely runtime info that does not
+// belong on the trait; the rest is mirrored from TOpDescriptor in
+// schemeshard__op_traits.h, which is the single source of truth for trait
+// fields. Extending the trait does NOT require changing this file unless we
+// want to expose the new field in `ops list` formatting.
+struct TOpRow {
     TString Name;
     NSO::EOperationType Type{};
-    EOperationClass Class = EOperationClass::Unknown;
-    bool CreateDirsFromName = false;
-    bool CreateAdditionalDirs = false;
-    bool NeedRewrite = false;
-    bool HasMakeOperationParts = false;
-    bool HasCollectChangingPaths = false;
+    TOpDescriptor Desc;
 };
 
 TStringBuf ClassName(EOperationClass c) {
@@ -53,39 +52,24 @@ TStringBuf ClassName(EOperationClass c) {
     return "?";
 }
 
-TOpInfo CollectInfo(NSO::EOperationType opType) {
-    TOpInfo info;
-    info.Type = opType;
-    info.Name = NSO::EOperationType_Name(opType);
+TOpRow CollectRow(NSO::EOperationType opType) {
+    TOpRow row;
+    row.Type = opType;
+    row.Name = NSO::EOperationType_Name(opType);
 
-    // DispatchOp routes by tx.GetOperationType(); we feed it a synthetic tx.
+    // DispatchOp routes by tx.GetOperationType(); feed it a synthetic tx and
+    // hand the matched trait type to NSchemeShard::Describe<>().
     NSO::TModifyScheme tx;
     tx.SetOperationType(opType);
-
     DispatchOp(tx, [&](auto traits) {
-        using Traits = decltype(traits);
-        info.Class = Traits::Class;
-        info.CreateDirsFromName = Traits::CreateDirsFromName;
-        info.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
-        info.NeedRewrite = Traits::NeedRewrite;
-        info.HasMakeOperationParts = requires {
-            Traits::MakeOperationParts(
-                std::declval<const TOperation&>(),
-                std::declval<const TTxTransaction&>(),
-                std::declval<TOperationContext&>());
-        };
-        info.HasCollectChangingPaths = requires {
-            Traits::CollectChangingPaths(
-                std::declval<const TTxTransaction&>(),
-                std::declval<TVector<TString>&>());
-        };
+        row.Desc = Describe<decltype(traits)>();
     });
 
-    return info;
+    return row;
 }
 
-TVector<TOpInfo> AllOps() {
-    TVector<TOpInfo> result;
+TVector<TOpRow> AllOps() {
+    TVector<TOpRow> result;
     THashSet<int> seen;
     const auto* d = NSO::EOperationType_descriptor();
     for (int i = 0; i < d->value_count(); ++i) {
@@ -93,12 +77,12 @@ TVector<TOpInfo> AllOps() {
         if (!seen.insert(v->number()).second) {
             continue; // proto enum may carry aliases sharing one number
         }
-        result.push_back(CollectInfo(static_cast<NSO::EOperationType>(v->number())));
+        result.push_back(CollectRow(static_cast<NSO::EOperationType>(v->number())));
     }
     return result;
 }
 
-TString FormatFlags(const TOpInfo& op) {
+TString FormatFlags(const TOpDescriptor& d) {
     TStringBuilder sb;
     auto add = [&](const char* tag) {
         if (sb.size() > 0) {
@@ -106,9 +90,9 @@ TString FormatFlags(const TOpInfo& op) {
         }
         sb << tag;
     };
-    if (op.CreateDirsFromName)   add("CreateDirsFromName");
-    if (op.CreateAdditionalDirs) add("CreateAdditionalDirs");
-    if (op.NeedRewrite)          add("NeedRewrite");
+    if (d.CreateDirsFromName)   add("CreateDirsFromName");
+    if (d.CreateAdditionalDirs) add("CreateAdditionalDirs");
+    if (d.NeedRewrite)          add("NeedRewrite");
     return sb;
 }
 
@@ -121,12 +105,12 @@ void PrintHeader() {
          << Endl;
 }
 
-void PrintRow(const TOpInfo& op) {
+void PrintRow(const TOpRow& op) {
     Cout << op.Name
-         << "\t" << ClassName(op.Class)
-         << "\t" << (op.HasMakeOperationParts   ? "yes" : "no")
-         << "\t" << (op.HasCollectChangingPaths ? "yes" : "no")
-         << "\t" << FormatFlags(op)
+         << "\t" << ClassName(op.Desc.Class)
+         << "\t" << (op.Desc.HasMakeOperationParts   ? "yes" : "no")
+         << "\t" << (op.Desc.HasCollectChangingPaths ? "yes" : "no")
+         << "\t" << FormatFlags(op.Desc)
          << Endl;
 }
 
@@ -134,9 +118,9 @@ bool MethodKnown(const TString& name) {
     return name == "MakeOperationParts" || name == "CollectChangingPaths";
 }
 
-bool HasMethod(const TOpInfo& op, const TString& name) {
-    if (name == "MakeOperationParts")   return op.HasMakeOperationParts;
-    if (name == "CollectChangingPaths") return op.HasCollectChangingPaths;
+bool HasMethod(const TOpDescriptor& d, const TString& name) {
+    if (name == "MakeOperationParts")   return d.HasMakeOperationParts;
+    if (name == "CollectChangingPaths") return d.HasCollectChangingPaths;
     return false;
 }
 
@@ -168,13 +152,13 @@ int CmdList(int argc, const char** argv) {
 
     PrintHeader();
     for (const auto& op : AllOps()) {
-        if (!classFilter.empty() && TStringBuf(ClassName(op.Class)) != classFilter) {
+        if (!classFilter.empty() && TStringBuf(ClassName(op.Desc.Class)) != classFilter) {
             continue;
         }
-        if (!hasFilter.empty() && !HasMethod(op, hasFilter)) {
+        if (!hasFilter.empty() && !HasMethod(op.Desc, hasFilter)) {
             continue;
         }
-        if (!missingFilter.empty() && HasMethod(op, missingFilter)) {
+        if (!missingFilter.empty() && HasMethod(op.Desc, missingFilter)) {
             continue;
         }
         PrintRow(op);
@@ -192,15 +176,16 @@ int CmdShow(int argc, const char** argv) {
         Cerr << "Unknown op: " << argv[1] << Endl;
         return 1;
     }
-    auto info = CollectInfo(opType);
-    Cout << "Name:                     " << info.Name << Endl;
-    Cout << "Number:                   " << static_cast<int>(info.Type) << Endl;
-    Cout << "Class:                    " << ClassName(info.Class) << Endl;
-    Cout << "CreateDirsFromName:       " << (info.CreateDirsFromName   ? "true" : "false") << Endl;
-    Cout << "CreateAdditionalDirs:     " << (info.CreateAdditionalDirs ? "true" : "false") << Endl;
-    Cout << "NeedRewrite:              " << (info.NeedRewrite          ? "true" : "false") << Endl;
-    Cout << "HasMakeOperationParts:    " << (info.HasMakeOperationParts   ? "true" : "false") << Endl;
-    Cout << "HasCollectChangingPaths:  " << (info.HasCollectChangingPaths ? "true" : "false") << Endl;
+    const auto row = CollectRow(opType);
+    const auto& d = row.Desc;
+    Cout << "Name:                     " << row.Name << Endl;
+    Cout << "Number:                   " << static_cast<int>(row.Type) << Endl;
+    Cout << "Class:                    " << ClassName(d.Class) << Endl;
+    Cout << "CreateDirsFromName:       " << (d.CreateDirsFromName       ? "true" : "false") << Endl;
+    Cout << "CreateAdditionalDirs:     " << (d.CreateAdditionalDirs     ? "true" : "false") << Endl;
+    Cout << "NeedRewrite:              " << (d.NeedRewrite              ? "true" : "false") << Endl;
+    Cout << "HasMakeOperationParts:    " << (d.HasMakeOperationParts    ? "true" : "false") << Endl;
+    Cout << "HasCollectChangingPaths:  " << (d.HasCollectChangingPaths  ? "true" : "false") << Endl;
     return 0;
 }
 
@@ -210,9 +195,9 @@ int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
     size_t fullyMigrated = 0;
     size_t partial = 0;
     for (const auto& op : ops) {
-        if (op.HasMakeOperationParts && op.HasCollectChangingPaths) {
+        if (op.Desc.HasMakeOperationParts && op.Desc.HasCollectChangingPaths) {
             ++fullyMigrated;
-        } else if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+        } else if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
             ++partial;
         }
     }
@@ -224,12 +209,12 @@ int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
     Cout << Endl;
 
     Cout << "Pending ops grouped by Class:" << Endl;
-    THashMap<EOperationClass, TVector<const TOpInfo*>> byClass;
+    THashMap<EOperationClass, TVector<const TOpRow*>> byClass;
     for (const auto& op : ops) {
-        if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+        if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
             continue;
         }
-        byClass[op.Class].push_back(&op);
+        byClass[op.Desc.Class].push_back(&op);
     }
     for (auto cls : {EOperationClass::Create, EOperationClass::Alter,
                      EOperationClass::Drop,   EOperationClass::Other,

--- a/ydb/tools/ss_tool/ut/op_inspect_ut.cpp
+++ b/ydb/tools/ss_tool/ut/op_inspect_ut.cpp
@@ -1,0 +1,130 @@
+#include <ydb/tools/ss_tool/lib/op_inspect.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/hash_set.h>
+
+using namespace NKikimr::NSchemeShard;
+using namespace NKikimr::NSchemeShard::NSsTool;
+namespace NSO = NKikimrSchemeOp;
+
+Y_UNIT_TEST_SUITE(SsToolOpInspect) {
+
+    Y_UNIT_TEST(ClassNameCoversEveryEnumerator) {
+        UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Create),  TStringBuf("Create"));
+        UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Alter),   TStringBuf("Alter"));
+        UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Drop),    TStringBuf("Drop"));
+        UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Other),   TStringBuf("Other"));
+        UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Unknown), TStringBuf("Unknown"));
+    }
+
+    Y_UNIT_TEST(MethodKnownAcceptsExactlyTheTwoSupportedNames) {
+        UNIT_ASSERT(MethodKnown("MakeOperationParts"));
+        UNIT_ASSERT(MethodKnown("CollectChangingPaths"));
+        UNIT_ASSERT(!MethodKnown(""));
+        UNIT_ASSERT(!MethodKnown("garbage"));
+        // Case-sensitive on purpose: a typo should not silently match.
+        UNIT_ASSERT(!MethodKnown("makeoperationparts"));
+    }
+
+    Y_UNIT_TEST(HasMethodReadsTheRightDescriptorField) {
+        TOpDescriptor d;
+        d.HasMakeOperationParts = true;
+        d.HasCollectChangingPaths = false;
+        UNIT_ASSERT(HasMethod(d, "MakeOperationParts"));
+        UNIT_ASSERT(!HasMethod(d, "CollectChangingPaths"));
+        // Unknown name returns false (callers validate via MethodKnown first).
+        UNIT_ASSERT(!HasMethod(d, "garbage"));
+    }
+
+    Y_UNIT_TEST(CollectRowFillsIdentityFromProto) {
+        const auto row = CollectRow(NSO::ESchemeOpCreateTable);
+        UNIT_ASSERT_VALUES_EQUAL(row.Name, "ESchemeOpCreateTable");
+        UNIT_ASSERT_EQUAL(row.Type, NSO::ESchemeOpCreateTable);
+    }
+
+    Y_UNIT_TEST(CreateTableIsFullyMigrated) {
+        // CreateTable is the pilot for the per-op module pattern: trait spec
+        // carries Class + both static methods.
+        const auto row = CollectRow(NSO::ESchemeOpCreateTable);
+        UNIT_ASSERT_EQUAL(row.Desc.Class, EOperationClass::Create);
+        UNIT_ASSERT(row.Desc.CreateDirsFromName);
+        UNIT_ASSERT(row.Desc.HasMakeOperationParts);
+        UNIT_ASSERT(row.Desc.HasCollectChangingPaths);
+    }
+
+    Y_UNIT_TEST(MkDirCarriesTraitFlagButNoModuleMethods) {
+        // MkDir has CreateDirsFromName in its trait spec but has not been
+        // migrated to the per-op module pattern.
+        const auto row = CollectRow(NSO::ESchemeOpMkDir);
+        UNIT_ASSERT(row.Desc.CreateDirsFromName);
+        UNIT_ASSERT(!row.Desc.HasMakeOperationParts);
+        UNIT_ASSERT(!row.Desc.HasCollectChangingPaths);
+    }
+
+    Y_UNIT_TEST(UnmigratedOpFallsBackToUnknownClass) {
+        // Only migrated ops set Class explicitly; everyone else inherits
+        // EOperationClass::Unknown from TSchemeTxTraitsFallback. DropTable
+        // has not been migrated, so its trait reports Unknown.
+        const auto row = CollectRow(NSO::ESchemeOpDropTable);
+        UNIT_ASSERT_EQUAL(row.Desc.Class, EOperationClass::Unknown);
+        UNIT_ASSERT(!row.Desc.HasMakeOperationParts);
+        UNIT_ASSERT(!row.Desc.HasCollectChangingPaths);
+    }
+
+    Y_UNIT_TEST(AllOpsCoversEveryDistinctEnumNumber) {
+        const auto ops = AllOps();
+
+        // Build the expected set of distinct enum numbers from the proto
+        // descriptor (proto enums may carry aliases that share a number).
+        const auto* d = NSO::EOperationType_descriptor();
+        THashSet<int> expected;
+        for (int i = 0; i < d->value_count(); ++i) {
+            expected.insert(d->value(i)->number());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(ops.size(), expected.size());
+
+        THashSet<int> got;
+        for (const auto& op : ops) {
+            UNIT_ASSERT_C(got.insert(static_cast<int>(op.Type)).second,
+                          "duplicate op number in AllOps()");
+        }
+        UNIT_ASSERT_EQUAL(got, expected);
+    }
+
+    Y_UNIT_TEST(AllOpsIsNonTrivialAndIncludesCreateTable) {
+        const auto ops = AllOps();
+        UNIT_ASSERT_C(ops.size() >= 50,
+                      "schemeshard should declare dozens of ops; got " << ops.size());
+
+        bool sawCreateTable = false;
+        for (const auto& op : ops) {
+            if (op.Type == NSO::ESchemeOpCreateTable) {
+                sawCreateTable = true;
+                break;
+            }
+        }
+        UNIT_ASSERT(sawCreateTable);
+    }
+
+    Y_UNIT_TEST(MigrationProgressIsMonotonic) {
+        // Anything reported as "fully migrated" must indeed have both module
+        // methods; anything reported as "partial" must have exactly one.
+        // Guards against regressions in CollectRow's dispatch wiring.
+        const auto ops = AllOps();
+        for (const auto& op : ops) {
+            if (op.Desc.HasMakeOperationParts && op.Desc.HasCollectChangingPaths) {
+                continue; // fully migrated
+            }
+            if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
+                continue; // partial
+            }
+            // Pending: neither method should be reported.
+            UNIT_ASSERT_C(!op.Desc.HasMakeOperationParts,
+                          "logic error for " << op.Name);
+            UNIT_ASSERT_C(!op.Desc.HasCollectChangingPaths,
+                          "logic error for " << op.Name);
+        }
+    }
+}

--- a/ydb/tools/ss_tool/ut/op_inspect_ut.cpp
+++ b/ydb/tools/ss_tool/ut/op_inspect_ut.cpp
@@ -18,12 +18,11 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
         UNIT_ASSERT_VALUES_EQUAL(ClassName(EOperationClass::Unknown), TStringBuf("Unknown"));
     }
 
-    Y_UNIT_TEST(MethodKnownAcceptsExactlyTheTwoSupportedNames) {
+    Y_UNIT_TEST(MethodKnownIsCaseSensitive) {
         UNIT_ASSERT(MethodKnown("MakeOperationParts"));
         UNIT_ASSERT(MethodKnown("CollectChangingPaths"));
         UNIT_ASSERT(!MethodKnown(""));
         UNIT_ASSERT(!MethodKnown("garbage"));
-        // Case-sensitive on purpose: a typo should not silently match.
         UNIT_ASSERT(!MethodKnown("makeoperationparts"));
     }
 
@@ -33,7 +32,6 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
         d.HasCollectChangingPaths = false;
         UNIT_ASSERT(HasMethod(d, "MakeOperationParts"));
         UNIT_ASSERT(!HasMethod(d, "CollectChangingPaths"));
-        // Unknown name returns false (callers validate via MethodKnown first).
         UNIT_ASSERT(!HasMethod(d, "garbage"));
     }
 
@@ -44,8 +42,6 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
     }
 
     Y_UNIT_TEST(CreateTableIsFullyMigrated) {
-        // CreateTable is the pilot for the per-op module pattern: trait spec
-        // carries Class + both static methods.
         const auto row = CollectRow(NSO::ESchemeOpCreateTable);
         UNIT_ASSERT_EQUAL(row.Desc.Class, EOperationClass::Create);
         UNIT_ASSERT(row.Desc.CreateDirsFromName);
@@ -54,8 +50,6 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
     }
 
     Y_UNIT_TEST(MkDirCarriesTraitFlagButNoModuleMethods) {
-        // MkDir has CreateDirsFromName in its trait spec but has not been
-        // migrated to the per-op module pattern.
         const auto row = CollectRow(NSO::ESchemeOpMkDir);
         UNIT_ASSERT(row.Desc.CreateDirsFromName);
         UNIT_ASSERT(!row.Desc.HasMakeOperationParts);
@@ -63,9 +57,6 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
     }
 
     Y_UNIT_TEST(UnmigratedOpFallsBackToUnknownClass) {
-        // Only migrated ops set Class explicitly; everyone else inherits
-        // EOperationClass::Unknown from TSchemeTxTraitsFallback. DropTable
-        // has not been migrated, so its trait reports Unknown.
         const auto row = CollectRow(NSO::ESchemeOpDropTable);
         UNIT_ASSERT_EQUAL(row.Desc.Class, EOperationClass::Unknown);
         UNIT_ASSERT(!row.Desc.HasMakeOperationParts);
@@ -75,8 +66,6 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
     Y_UNIT_TEST(AllOpsCoversEveryDistinctEnumNumber) {
         const auto ops = AllOps();
 
-        // Build the expected set of distinct enum numbers from the proto
-        // descriptor (proto enums may carry aliases that share a number).
         const auto* d = NSO::EOperationType_descriptor();
         THashSet<int> expected;
         for (int i = 0; i < d->value_count(); ++i) {
@@ -95,8 +84,7 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
 
     Y_UNIT_TEST(AllOpsIsNonTrivialAndIncludesCreateTable) {
         const auto ops = AllOps();
-        UNIT_ASSERT_C(ops.size() >= 50,
-                      "schemeshard should declare dozens of ops; got " << ops.size());
+        UNIT_ASSERT_C(ops.size() >= 50, "got " << ops.size());
 
         bool sawCreateTable = false;
         for (const auto& op : ops) {
@@ -106,25 +94,5 @@ Y_UNIT_TEST_SUITE(SsToolOpInspect) {
             }
         }
         UNIT_ASSERT(sawCreateTable);
-    }
-
-    Y_UNIT_TEST(MigrationProgressIsMonotonic) {
-        // Anything reported as "fully migrated" must indeed have both module
-        // methods; anything reported as "partial" must have exactly one.
-        // Guards against regressions in CollectRow's dispatch wiring.
-        const auto ops = AllOps();
-        for (const auto& op : ops) {
-            if (op.Desc.HasMakeOperationParts && op.Desc.HasCollectChangingPaths) {
-                continue; // fully migrated
-            }
-            if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
-                continue; // partial
-            }
-            // Pending: neither method should be reported.
-            UNIT_ASSERT_C(!op.Desc.HasMakeOperationParts,
-                          "logic error for " << op.Name);
-            UNIT_ASSERT_C(!op.Desc.HasCollectChangingPaths,
-                          "logic error for " << op.Name);
-        }
     }
 }

--- a/ydb/tools/ss_tool/ut/ya.make
+++ b/ydb/tools/ss_tool/ut/ya.make
@@ -1,0 +1,7 @@
+UNITTEST_FOR(ydb/tools/ss_tool/lib)
+
+SRCS(
+    op_inspect_ut.cpp
+)
+
+END()

--- a/ydb/tools/ss_tool/ya.make
+++ b/ydb/tools/ss_tool/ya.make
@@ -6,8 +6,15 @@ SRCS(
 
 PEERDIR(
     library/cpp/getopt
-    ydb/core/protos
-    ydb/core/tx/schemeshard
+    ydb/tools/ss_tool/lib
 )
 
 END()
+
+RECURSE(
+    lib
+)
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/tools/ss_tool/ya.make
+++ b/ydb/tools/ss_tool/ya.make
@@ -1,0 +1,13 @@
+PROGRAM(ss_tool)
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    library/cpp/getopt
+    ydb/core/protos
+    ydb/core/tx/schemeshard
+)
+
+END()

--- a/ydb/tools/ya.make
+++ b/ydb/tools/ya.make
@@ -5,6 +5,7 @@ RECURSE(
     partcheck
     query_replay
     query_replay_yt
+    ss_tool
     stress_tool
     tsserver
     tstool


### PR DESCRIPTION
## Summary

Two related changes that together demonstrate the per-op module pattern for schemeshard operations and the by-aspect view it enables.

### Part 1 — Per-op module pilot (CreateTable)

Adding one schemeshard operation today touches 5+ central files (proto enum, `MakeOperationParts` factory switch, `GetOperationClass` switch, `ExtractChangingPaths` audit switch, `op_traits.h` specialization). This pilot collapses CreateTable's footprint into a single source of truth — `TSchemeTxTraits<ESchemeOpCreateTable>`.

- Lift `EOperationClass` into `schemeshard__op_traits.h` so trait specs can carry classification as a compile-time constant. Added `Class = Unknown` to `TSchemeTxTraitsFallback`.
- Extend `TSchemeTxTraits<ESchemeOpCreateTable>` with `Class = Create`, `static MakeOperationParts(...)`, `static CollectChangingPaths(...)`. Methods defined in `schemeshard__operation_create_table.cpp` next to existing `NOperation::GetTargetName/SetName`.
- `MakeOperationParts` (factory) and `ExtractChangingPaths` (audit log) start with a `DispatchOp + if constexpr requires` prelude that routes to the trait method when defined; the **CreateTable case is deleted from both switches**. Future ops that opt into the pattern are picked up automatically.
- `static_assert` in `schemeshard__op_traits.cpp` guards parity between the trait's `Class` and the `GetOperationClass()` switch entry during the incremental migration.

### Part 2 — `ss_tool`: by-aspect inspector

The per-op `.cpp` gives the source-organization view ("everything CreateTable in one file"). `ss_tool` gives the orthogonal cross-cutting view ("all Create-class ops", "what's the migration progress?") by iterating the proto enum and reading trait metadata via the existing `DispatchOp`.

```
ss_tool ops list [--class=Create|Alter|Drop|Other|Unknown]
                 [--has=MakeOperationParts|CollectChangingPaths]
                 [--missing=MakeOperationParts|CollectChangingPaths]
ss_tool ops show <OpName>
ss_tool ops migration-status   # progress dashboard during the rollout
```

Single source of truth: the trait header owns `TOpDescriptor` (POD with the trait fields) and `constexpr Describe<Traits>()`. The tool keeps only runtime-only identity bits (name + enum number) and gets the rest from `Describe<>()`. New trait fields ripple: extend `TSchemeTxTraitsFallback`, extend `TOpDescriptor`, extend `Describe()` — `ss_tool` picks them up in `ops show` automatically.

### Why one PR

The producer (per-op trait module) and the consumer (`ss_tool` inspector) are easier to review together — reviewers can see how the trait fields and the methods declared in Part 1 are exposed and validated in Part 2.

## Files

**Part 1**
- `ydb/core/tx/schemeshard/schemeshard__op_traits.h` — `EOperationClass` lifted; `Class`, `MakeOperationParts`, `CollectChangingPaths` on `TSchemeTxTraits<ESchemeOpCreateTable>`; `TOpDescriptor` + `Describe<>()` for tooling.
- `ydb/core/tx/schemeshard/schemeshard__op_traits.cpp` — parity `static_assert`; enum moved to header.
- `ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp` — definitions of the trait's static methods.
- `ydb/core/tx/schemeshard/schemeshard__operation.cpp` — `DispatchOp` prelude in `MakeOperationParts`; CreateTable case deleted.
- `ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp` — `DispatchOp` prelude in `ExtractChangingPaths`; CreateTable case deleted.

**Part 2**
- `ydb/tools/ss_tool/main.cpp` — single-file CLI (~250 lines).
- `ydb/tools/ss_tool/ya.make` — `PROGRAM(ss_tool)`.
- `ydb/tools/ya.make` — registered in `RECURSE`.

## Test plan

- [ ] `./ya make --build relwithdebinfo ydb/core/tx/schemeshard` — schemeshard compiles
- [ ] `./ya make --build relwithdebinfo -tA ydb/core/tx/schemeshard` — schemeshard tests pass
- [ ] `./ya make --build relwithdebinfo ydb/tools/ss_tool` — tool compiles
- [ ] `./ya tool ss_tool ops list` — prints all ops with class + flags
- [ ] `./ya tool ss_tool ops show ESchemeOpCreateTable` — `Class=Create`, `HasMakeOperationParts=true`, `HasCollectChangingPaths=true`
- [ ] `./ya tool ss_tool ops migration-status` — pending count = total - 1 (just CreateTable migrated)
- [ ] CreateTable / CopyTable code paths unchanged at runtime (one-to-one delegation)