### PR TITLE
ss_tool: by-aspect inspector for schemeshard operation traits

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -10,6 +10,7 @@
 #include <util/generic/string.h>
 
 #include <optional>
+#include <utility>  // std::declval, used by Describe<>()
 
 namespace NKikimr::NSchemeShard {
 
@@ -280,5 +281,45 @@ bool Rewrite(TTraits traits, TTxTransaction& tx) {
 }
 
 bool IsCreatePathOperation(NKikimrSchemeOp::EOperationType op);
+
+// --- Trait description -----------------------------------------------------
+//
+// Materialized snapshot of the static-constexpr fields of a TSchemeTxTraits<>
+// specialization. Lives next to the trait itself so the trait header is the
+// single source of truth for "what an op-trait carries"; tooling (ss_tool,
+// docs codegen, etc.) consumes this struct instead of mirroring the field
+// list. When you add a field to TSchemeTxTraitsFallback, also add it here
+// and extend Describe() below; nothing else needs to change.
+
+struct TOpDescriptor {
+    EOperationClass Class = EOperationClass::Unknown;
+    bool CreateDirsFromName = false;
+    bool CreateAdditionalDirs = false;
+    bool NeedRewrite = false;
+    // Derived: which of the per-op module static methods the trait declares.
+    bool HasMakeOperationParts = false;
+    bool HasCollectChangingPaths = false;
+};
+
+template <class Traits>
+constexpr TOpDescriptor Describe() {
+    TOpDescriptor d;
+    d.Class                = Traits::Class;
+    d.CreateDirsFromName   = Traits::CreateDirsFromName;
+    d.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
+    d.NeedRewrite          = Traits::NeedRewrite;
+    d.HasMakeOperationParts = requires {
+        Traits::MakeOperationParts(
+            std::declval<const TOperation&>(),
+            std::declval<const TTxTransaction&>(),
+            std::declval<TOperationContext&>());
+    };
+    d.HasCollectChangingPaths = requires {
+        Traits::CollectChangingPaths(
+            std::declval<const TTxTransaction&>(),
+            std::declval<TVector<TString>&>());
+    };
+    return d;
+}
 
 }  // namespace NKikimr::NSchemeShard

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -1,0 +1,270 @@
+// ss_tool — read-only inspector for the schemeshard operation trait system.
+//
+// The schemeshard trait registry (TSchemeTxTraits<EOperationType>) carries
+// per-op metadata at compile time. The per-op `.cpp` view ("show me everything
+// about CreateTable") lives in the source. This tool exposes the orthogonal
+// by-aspect view ("show me all Create-class ops", "show me ops that still
+// lack CollectChangingPaths") by iterating the proto enum and reading the
+// trait fields via the existing DispatchOp infrastructure.
+
+#include <ydb/core/tx/schemeshard/schemeshard__dispatch_op.h>
+#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+
+#include <library/cpp/getopt/last_getopt.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/stream/output.h>
+#include <util/string/builder.h>
+
+#include <utility>
+
+namespace {
+
+using namespace NKikimr::NSchemeShard;
+namespace NSO = NKikimrSchemeOp;
+
+// Snapshot of the metadata we read out of TSchemeTxTraits<op>. Extend this
+// struct (and CollectInfo below) when new trait fields land.
+struct TOpInfo {
+    TString Name;
+    NSO::EOperationType Type{};
+    EOperationClass Class = EOperationClass::Unknown;
+    bool CreateDirsFromName = false;
+    bool CreateAdditionalDirs = false;
+    bool NeedRewrite = false;
+    bool HasMakeOperationParts = false;
+    bool HasCollectChangingPaths = false;
+};
+
+TStringBuf ClassName(EOperationClass c) {
+    switch (c) {
+        case EOperationClass::Create:  return "Create";
+        case EOperationClass::Alter:   return "Alter";
+        case EOperationClass::Drop:    return "Drop";
+        case EOperationClass::Other:   return "Other";
+        case EOperationClass::Unknown: return "Unknown";
+    }
+    return "?";
+}
+
+TOpInfo CollectInfo(NSO::EOperationType opType) {
+    TOpInfo info;
+    info.Type = opType;
+    info.Name = NSO::EOperationType_Name(opType);
+
+    // DispatchOp routes by tx.GetOperationType(); we feed it a synthetic tx.
+    NSO::TModifyScheme tx;
+    tx.SetOperationType(opType);
+
+    DispatchOp(tx, [&](auto traits) {
+        using Traits = decltype(traits);
+        info.Class = Traits::Class;
+        info.CreateDirsFromName = Traits::CreateDirsFromName;
+        info.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
+        info.NeedRewrite = Traits::NeedRewrite;
+        info.HasMakeOperationParts = requires {
+            Traits::MakeOperationParts(
+                std::declval<const TOperation&>(),
+                std::declval<const TTxTransaction&>(),
+                std::declval<TOperationContext&>());
+        };
+        info.HasCollectChangingPaths = requires {
+            Traits::CollectChangingPaths(
+                std::declval<const TTxTransaction&>(),
+                std::declval<TVector<TString>&>());
+        };
+    });
+
+    return info;
+}
+
+TVector<TOpInfo> AllOps() {
+    TVector<TOpInfo> result;
+    THashSet<int> seen;
+    const auto* d = NSO::EOperationType_descriptor();
+    for (int i = 0; i < d->value_count(); ++i) {
+        const auto* v = d->value(i);
+        if (!seen.insert(v->number()).second) {
+            continue; // proto enum may carry aliases sharing one number
+        }
+        result.push_back(CollectInfo(static_cast<NSO::EOperationType>(v->number())));
+    }
+    return result;
+}
+
+TString FormatFlags(const TOpInfo& op) {
+    TStringBuilder sb;
+    auto add = [&](const char* tag) {
+        if (sb.size() > 0) {
+            sb << ",";
+        }
+        sb << tag;
+    };
+    if (op.CreateDirsFromName)   add("CreateDirsFromName");
+    if (op.CreateAdditionalDirs) add("CreateAdditionalDirs");
+    if (op.NeedRewrite)          add("NeedRewrite");
+    return sb;
+}
+
+void PrintHeader() {
+    Cout << "NAME"
+         << "\tCLASS"
+         << "\tMakeOperationParts"
+         << "\tCollectChangingPaths"
+         << "\tFLAGS"
+         << Endl;
+}
+
+void PrintRow(const TOpInfo& op) {
+    Cout << op.Name
+         << "\t" << ClassName(op.Class)
+         << "\t" << (op.HasMakeOperationParts   ? "yes" : "no")
+         << "\t" << (op.HasCollectChangingPaths ? "yes" : "no")
+         << "\t" << FormatFlags(op)
+         << Endl;
+}
+
+bool MethodKnown(const TString& name) {
+    return name == "MakeOperationParts" || name == "CollectChangingPaths";
+}
+
+bool HasMethod(const TOpInfo& op, const TString& name) {
+    if (name == "MakeOperationParts")   return op.HasMakeOperationParts;
+    if (name == "CollectChangingPaths") return op.HasCollectChangingPaths;
+    return false;
+}
+
+int CmdList(int argc, const char** argv) {
+    TString classFilter;
+    TString hasFilter;
+    TString missingFilter;
+
+    NLastGetopt::TOpts opts;
+    opts.AddLongOption("class", "filter by class: Create|Alter|Drop|Other|Unknown")
+        .StoreResult(&classFilter);
+    opts.AddLongOption("has", "only ops whose trait defines METHOD")
+        .StoreResult(&hasFilter);
+    opts.AddLongOption("missing", "only ops whose trait does NOT define METHOD")
+        .StoreResult(&missingFilter);
+    opts.AddHelpOption();
+    NLastGetopt::TOptsParseResult res(&opts, argc, argv);
+
+    if (!hasFilter.empty() && !MethodKnown(hasFilter)) {
+        Cerr << "Unknown method '" << hasFilter
+             << "'; expected MakeOperationParts or CollectChangingPaths" << Endl;
+        return 1;
+    }
+    if (!missingFilter.empty() && !MethodKnown(missingFilter)) {
+        Cerr << "Unknown method '" << missingFilter
+             << "'; expected MakeOperationParts or CollectChangingPaths" << Endl;
+        return 1;
+    }
+
+    PrintHeader();
+    for (const auto& op : AllOps()) {
+        if (!classFilter.empty() && TStringBuf(ClassName(op.Class)) != classFilter) {
+            continue;
+        }
+        if (!hasFilter.empty() && !HasMethod(op, hasFilter)) {
+            continue;
+        }
+        if (!missingFilter.empty() && HasMethod(op, missingFilter)) {
+            continue;
+        }
+        PrintRow(op);
+    }
+    return 0;
+}
+
+int CmdShow(int argc, const char** argv) {
+    if (argc < 2) {
+        Cerr << "Usage: ss_tool ops show <OpName>" << Endl;
+        return 1;
+    }
+    NSO::EOperationType opType{};
+    if (!NSO::EOperationType_Parse(argv[1], &opType)) {
+        Cerr << "Unknown op: " << argv[1] << Endl;
+        return 1;
+    }
+    auto info = CollectInfo(opType);
+    Cout << "Name:                     " << info.Name << Endl;
+    Cout << "Number:                   " << static_cast<int>(info.Type) << Endl;
+    Cout << "Class:                    " << ClassName(info.Class) << Endl;
+    Cout << "CreateDirsFromName:       " << (info.CreateDirsFromName   ? "true" : "false") << Endl;
+    Cout << "CreateAdditionalDirs:     " << (info.CreateAdditionalDirs ? "true" : "false") << Endl;
+    Cout << "NeedRewrite:              " << (info.NeedRewrite          ? "true" : "false") << Endl;
+    Cout << "HasMakeOperationParts:    " << (info.HasMakeOperationParts   ? "true" : "false") << Endl;
+    Cout << "HasCollectChangingPaths:  " << (info.HasCollectChangingPaths ? "true" : "false") << Endl;
+    return 0;
+}
+
+int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
+    auto ops = AllOps();
+    size_t total = ops.size();
+    size_t fullyMigrated = 0;
+    size_t partial = 0;
+    for (const auto& op : ops) {
+        if (op.HasMakeOperationParts && op.HasCollectChangingPaths) {
+            ++fullyMigrated;
+        } else if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+            ++partial;
+        }
+    }
+    Cout << "Total ops:      " << total << Endl;
+    Cout << "Fully migrated: " << fullyMigrated
+         << "  (trait defines both MakeOperationParts and CollectChangingPaths)" << Endl;
+    Cout << "Partial:        " << partial << Endl;
+    Cout << "Pending:        " << (total - fullyMigrated - partial) << Endl;
+    Cout << Endl;
+
+    Cout << "Pending ops grouped by Class:" << Endl;
+    THashMap<EOperationClass, TVector<const TOpInfo*>> byClass;
+    for (const auto& op : ops) {
+        if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+            continue;
+        }
+        byClass[op.Class].push_back(&op);
+    }
+    for (auto cls : {EOperationClass::Create, EOperationClass::Alter,
+                     EOperationClass::Drop,   EOperationClass::Other,
+                     EOperationClass::Unknown}) {
+        const auto& list = byClass[cls];
+        if (list.empty()) {
+            continue;
+        }
+        Cout << "  " << ClassName(cls) << " (" << list.size() << "):" << Endl;
+        for (const auto* op : list) {
+            Cout << "    " << op->Name << Endl;
+        }
+    }
+    return 0;
+}
+
+void PrintUsage(const char* argv0) {
+    Cerr << "Usage: " << argv0 << " ops <subcommand> [args...]" << Endl;
+    Cerr << "Subcommands:" << Endl;
+    Cerr << "  list [--class=X] [--has=METHOD] [--missing=METHOD]" << Endl;
+    Cerr << "  show <OpName>" << Endl;
+    Cerr << "  migration-status" << Endl;
+}
+
+} // namespace
+
+int main(int argc, const char** argv) {
+    if (argc < 3 || TString(argv[1]) != "ops") {
+        PrintUsage(argv[0]);
+        return 1;
+    }
+    const TString sub = argv[2];
+    if (sub == "list")             return CmdList(argc - 2, argv + 2);
+    if (sub == "show")             return CmdShow(argc - 2, argv + 2);
+    if (sub == "migration-status") return CmdMigrationStatus(argc - 2, argv + 2);
+    PrintUsage(argv[0]);
+    return 1;
+}

--- a/ydb/tools/ss_tool/main.cpp
+++ b/ydb/tools/ss_tool/main.cpp
@@ -29,17 +29,16 @@ namespace {
 using namespace NKikimr::NSchemeShard;
 namespace NSO = NKikimrSchemeOp;
 
-// Snapshot of the metadata we read out of TSchemeTxTraits<op>. Extend this
-// struct (and CollectInfo below) when new trait fields land.
-struct TOpInfo {
+// One row in the tool's tables: identity (name + enum number) plus the
+// trait-derived metadata. Identity is purely runtime info that does not
+// belong on the trait; the rest is mirrored from TOpDescriptor in
+// schemeshard__op_traits.h, which is the single source of truth for trait
+// fields. Extending the trait does NOT require changing this file unless we
+// want to expose the new field in `ops list` formatting.
+struct TOpRow {
     TString Name;
     NSO::EOperationType Type{};
-    EOperationClass Class = EOperationClass::Unknown;
-    bool CreateDirsFromName = false;
-    bool CreateAdditionalDirs = false;
-    bool NeedRewrite = false;
-    bool HasMakeOperationParts = false;
-    bool HasCollectChangingPaths = false;
+    TOpDescriptor Desc;
 };
 
 TStringBuf ClassName(EOperationClass c) {
@@ -53,39 +52,24 @@ TStringBuf ClassName(EOperationClass c) {
     return "?";
 }
 
-TOpInfo CollectInfo(NSO::EOperationType opType) {
-    TOpInfo info;
-    info.Type = opType;
-    info.Name = NSO::EOperationType_Name(opType);
+TOpRow CollectRow(NSO::EOperationType opType) {
+    TOpRow row;
+    row.Type = opType;
+    row.Name = NSO::EOperationType_Name(opType);
 
-    // DispatchOp routes by tx.GetOperationType(); we feed it a synthetic tx.
+    // DispatchOp routes by tx.GetOperationType(); feed it a synthetic tx and
+    // hand the matched trait type to NSchemeShard::Describe<>().
     NSO::TModifyScheme tx;
     tx.SetOperationType(opType);
-
     DispatchOp(tx, [&](auto traits) {
-        using Traits = decltype(traits);
-        info.Class = Traits::Class;
-        info.CreateDirsFromName = Traits::CreateDirsFromName;
-        info.CreateAdditionalDirs = Traits::CreateAdditionalDirs;
-        info.NeedRewrite = Traits::NeedRewrite;
-        info.HasMakeOperationParts = requires {
-            Traits::MakeOperationParts(
-                std::declval<const TOperation&>(),
-                std::declval<const TTxTransaction&>(),
-                std::declval<TOperationContext&>());
-        };
-        info.HasCollectChangingPaths = requires {
-            Traits::CollectChangingPaths(
-                std::declval<const TTxTransaction&>(),
-                std::declval<TVector<TString>&>());
-        };
+        row.Desc = Describe<decltype(traits)>();
     });
 
-    return info;
+    return row;
 }
 
-TVector<TOpInfo> AllOps() {
-    TVector<TOpInfo> result;
+TVector<TOpRow> AllOps() {
+    TVector<TOpRow> result;
     THashSet<int> seen;
     const auto* d = NSO::EOperationType_descriptor();
     for (int i = 0; i < d->value_count(); ++i) {
@@ -93,12 +77,12 @@ TVector<TOpInfo> AllOps() {
         if (!seen.insert(v->number()).second) {
             continue; // proto enum may carry aliases sharing one number
         }
-        result.push_back(CollectInfo(static_cast<NSO::EOperationType>(v->number())));
+        result.push_back(CollectRow(static_cast<NSO::EOperationType>(v->number())));
     }
     return result;
 }
 
-TString FormatFlags(const TOpInfo& op) {
+TString FormatFlags(const TOpDescriptor& d) {
     TStringBuilder sb;
     auto add = [&](const char* tag) {
         if (sb.size() > 0) {
@@ -106,9 +90,9 @@ TString FormatFlags(const TOpInfo& op) {
         }
         sb << tag;
     };
-    if (op.CreateDirsFromName)   add("CreateDirsFromName");
-    if (op.CreateAdditionalDirs) add("CreateAdditionalDirs");
-    if (op.NeedRewrite)          add("NeedRewrite");
+    if (d.CreateDirsFromName)   add("CreateDirsFromName");
+    if (d.CreateAdditionalDirs) add("CreateAdditionalDirs");
+    if (d.NeedRewrite)          add("NeedRewrite");
     return sb;
 }
 
@@ -121,12 +105,12 @@ void PrintHeader() {
          << Endl;
 }
 
-void PrintRow(const TOpInfo& op) {
+void PrintRow(const TOpRow& op) {
     Cout << op.Name
-         << "\t" << ClassName(op.Class)
-         << "\t" << (op.HasMakeOperationParts   ? "yes" : "no")
-         << "\t" << (op.HasCollectChangingPaths ? "yes" : "no")
-         << "\t" << FormatFlags(op)
+         << "\t" << ClassName(op.Desc.Class)
+         << "\t" << (op.Desc.HasMakeOperationParts   ? "yes" : "no")
+         << "\t" << (op.Desc.HasCollectChangingPaths ? "yes" : "no")
+         << "\t" << FormatFlags(op.Desc)
          << Endl;
 }
 
@@ -134,9 +118,9 @@ bool MethodKnown(const TString& name) {
     return name == "MakeOperationParts" || name == "CollectChangingPaths";
 }
 
-bool HasMethod(const TOpInfo& op, const TString& name) {
-    if (name == "MakeOperationParts")   return op.HasMakeOperationParts;
-    if (name == "CollectChangingPaths") return op.HasCollectChangingPaths;
+bool HasMethod(const TOpDescriptor& d, const TString& name) {
+    if (name == "MakeOperationParts")   return d.HasMakeOperationParts;
+    if (name == "CollectChangingPaths") return d.HasCollectChangingPaths;
     return false;
 }
 
@@ -168,13 +152,13 @@ int CmdList(int argc, const char** argv) {
 
     PrintHeader();
     for (const auto& op : AllOps()) {
-        if (!classFilter.empty() && TStringBuf(ClassName(op.Class)) != classFilter) {
+        if (!classFilter.empty() && TStringBuf(ClassName(op.Desc.Class)) != classFilter) {
             continue;
         }
-        if (!hasFilter.empty() && !HasMethod(op, hasFilter)) {
+        if (!hasFilter.empty() && !HasMethod(op.Desc, hasFilter)) {
             continue;
         }
-        if (!missingFilter.empty() && HasMethod(op, missingFilter)) {
+        if (!missingFilter.empty() && HasMethod(op.Desc, missingFilter)) {
             continue;
         }
         PrintRow(op);
@@ -192,15 +176,16 @@ int CmdShow(int argc, const char** argv) {
         Cerr << "Unknown op: " << argv[1] << Endl;
         return 1;
     }
-    auto info = CollectInfo(opType);
-    Cout << "Name:                     " << info.Name << Endl;
-    Cout << "Number:                   " << static_cast<int>(info.Type) << Endl;
-    Cout << "Class:                    " << ClassName(info.Class) << Endl;
-    Cout << "CreateDirsFromName:       " << (info.CreateDirsFromName   ? "true" : "false") << Endl;
-    Cout << "CreateAdditionalDirs:     " << (info.CreateAdditionalDirs ? "true" : "false") << Endl;
-    Cout << "NeedRewrite:              " << (info.NeedRewrite          ? "true" : "false") << Endl;
-    Cout << "HasMakeOperationParts:    " << (info.HasMakeOperationParts   ? "true" : "false") << Endl;
-    Cout << "HasCollectChangingPaths:  " << (info.HasCollectChangingPaths ? "true" : "false") << Endl;
+    const auto row = CollectRow(opType);
+    const auto& d = row.Desc;
+    Cout << "Name:                     " << row.Name << Endl;
+    Cout << "Number:                   " << static_cast<int>(row.Type) << Endl;
+    Cout << "Class:                    " << ClassName(d.Class) << Endl;
+    Cout << "CreateDirsFromName:       " << (d.CreateDirsFromName       ? "true" : "false") << Endl;
+    Cout << "CreateAdditionalDirs:     " << (d.CreateAdditionalDirs     ? "true" : "false") << Endl;
+    Cout << "NeedRewrite:              " << (d.NeedRewrite              ? "true" : "false") << Endl;
+    Cout << "HasMakeOperationParts:    " << (d.HasMakeOperationParts    ? "true" : "false") << Endl;
+    Cout << "HasCollectChangingPaths:  " << (d.HasCollectChangingPaths  ? "true" : "false") << Endl;
     return 0;
 }
 
@@ -210,9 +195,9 @@ int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
     size_t fullyMigrated = 0;
     size_t partial = 0;
     for (const auto& op : ops) {
-        if (op.HasMakeOperationParts && op.HasCollectChangingPaths) {
+        if (op.Desc.HasMakeOperationParts && op.Desc.HasCollectChangingPaths) {
             ++fullyMigrated;
-        } else if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+        } else if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
             ++partial;
         }
     }
@@ -224,12 +209,12 @@ int CmdMigrationStatus(int /*argc*/, const char** /*argv*/) {
     Cout << Endl;
 
     Cout << "Pending ops grouped by Class:" << Endl;
-    THashMap<EOperationClass, TVector<const TOpInfo*>> byClass;
+    THashMap<EOperationClass, TVector<const TOpRow*>> byClass;
     for (const auto& op : ops) {
-        if (op.HasMakeOperationParts || op.HasCollectChangingPaths) {
+        if (op.Desc.HasMakeOperationParts || op.Desc.HasCollectChangingPaths) {
             continue;
         }
-        byClass[op.Class].push_back(&op);
+        byClass[op.Desc.Class].push_back(&op);
     }
     for (auto cls : {EOperationClass::Create, EOperationClass::Alter,
                      EOperationClass::Drop,   EOperationClass::Other,

--- a/ydb/tools/ss_tool/ya.make
+++ b/ydb/tools/ss_tool/ya.make
@@ -1,0 +1,13 @@
+PROGRAM(ss_tool)
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    library/cpp/getopt
+    ydb/core/protos
+    ydb/core/tx/schemeshard
+)
+
+END()

--- a/ydb/tools/ya.make
+++ b/ydb/tools/ya.make
@@ -5,6 +5,7 @@ RECURSE(
     partcheck
     query_replay
     query_replay_yt
+    ss_tool
     stress_tool
     tsserver
     tstool


### PR DESCRIPTION
## Summary

Adds `ss_tool`, a small read-only CLI that surfaces the by-aspect view of the schemeshard operation trait system. The per-op `.cpp` gives the source-organization view ("everything about CreateTable in one file"); this tool gives the orthogonal cross-cutting view that we lose when knowledge is distributed.

**Stacked on top of #23** (the per-op module pilot) — depends on the `Class` field and the `MakeOperationParts` / `CollectChangingPaths` static methods that #23 introduced on `TSchemeTxTraits<>`. The base of this PR is the `schemeshard-enhancement` branch.

## Why

Both views matter:

- **By op (source view).** Adding/maintaining one operation: open `schemeshard__operation_<foo>.cpp`, see everything about it.
- **By aspect (tool view).** Reviewing the system: "show me all Create-class ops", "which ops still don't have a per-op `CollectChangingPaths`?", "what's the migration progress?"

The trait registry already encodes everything needed for the second view. This tool just exposes it.

## Commands

```
ss_tool ops list [--class=Create|Alter|Drop|Other|Unknown]
                 [--has=MakeOperationParts|CollectChangingPaths]
                 [--missing=MakeOperationParts|CollectChangingPaths]
ss_tool ops show <OpName>
ss_tool ops migration-status
```

`migration-status` is the killer command during the per-op rollout — it groups pending ops by class so you can prioritize ("next Create-class ops to migrate").

## How it works

- Iterates `NKikimrSchemeOp::EOperationType_descriptor()` to enumerate ops (deduplicates aliases by enum number).
- For each, builds a synthetic `TModifyScheme` and calls the existing `DispatchOp(tx, lambda)` to instantiate the matching `TSchemeTxTraits<op>`.
- Reads `static constexpr` fields directly (`Class`, `CreateDirsFromName`, ...) and uses C++20 `requires { ... }` to introspect which static methods (`MakeOperationParts`, `CollectChangingPaths`) the trait declares.
- No new codegen needed — fully orthogonal to existing infrastructure.

## Files

- `ydb/tools/ss_tool/main.cpp` — single-file implementation (~250 lines)
- `ydb/tools/ss_tool/ya.make` — `PROGRAM(ss_tool)` peerdir-ing schemeshard + getopt
- `ydb/tools/ya.make` — register the tool in the parent `RECURSE` list

## Test plan

- [ ] `./ya make --build relwithdebinfo ydb/tools/ss_tool` — builds
- [ ] `./ya tool ss_tool ops list` — prints all ops with class + flags
- [ ] `./ya tool ss_tool ops list --class=Create` — filters
- [ ] `./ya tool ss_tool ops show ESchemeOpCreateTable` — detail view; should show `Class=Create`, `HasMakeOperationParts=true`, `HasCollectChangingPaths=true` after #23
- [ ] `./ya tool ss_tool ops migration-status` — pending count = total - 1 (just CreateTable migrated so far)